### PR TITLE
fix: address post-merge review findings from PR #3

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -135,8 +135,6 @@ impl Channel {
 
     /// Return all completed, non-collided transmissions as received frames.
     ///
-    /// The `_node_id` parameter is accepted for API symmetry but does not filter results.
-    ///
     /// # Examples
     ///
     /// ```
@@ -154,11 +152,11 @@ impl Channel {
     /// };
     /// ch.begin_transmission(NodeId(1), &tx, 0);
     /// ch.resolve_at(50_000);
-    /// let received = ch.deliver_to(NodeId(2), 50_000);
+    /// let received = ch.deliver_to(50_000);
     /// assert_eq!(received.len(), 1);
     /// assert_eq!(received[0].payload, vec![0x01]);
     /// ```
-    pub fn deliver_to(&self, _node_id: NodeId, time: SimTime) -> Vec<RxMetadata> {
+    pub fn deliver_to(&self, time: SimTime) -> Vec<RxMetadata> {
         self.completed
             .iter()
             .filter(|tx| tx.end <= time && !tx.collided)
@@ -256,7 +254,7 @@ mod tests {
         let tx = make_tx(7, 868_100_000, 50_000);
         ch.begin_transmission(NodeId(1), &tx, 0);
         ch.resolve_at(50_000);
-        let delivered = ch.deliver_to(NodeId(2), 50_000);
+        let delivered = ch.deliver_to(50_000);
         assert_eq!(delivered.len(), 1);
         assert_eq!(delivered[0].payload, vec![0x01, 0x02]);
     }
@@ -269,7 +267,7 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(NodeId(3), 60_000);
+        let delivered = ch.deliver_to(60_000);
         assert_eq!(delivered.len(), 0);
     }
 
@@ -281,7 +279,7 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(NodeId(3), 60_000);
+        let delivered = ch.deliver_to(60_000);
         assert_eq!(delivered.len(), 2);
     }
 
@@ -293,7 +291,7 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(NodeId(3), 60_000);
+        let delivered = ch.deliver_to(60_000);
         assert_eq!(delivered.len(), 2);
     }
 
@@ -307,7 +305,7 @@ mod tests {
         ch.drain_completed();
         ch.begin_transmission(NodeId(2), &tx2, 60_000);
         ch.resolve_at(110_000);
-        let delivered = ch.deliver_to(NodeId(3), 110_000);
+        let delivered = ch.deliver_to(110_000);
         assert_eq!(delivered.len(), 1);
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -134,6 +134,11 @@ impl Scheduler {
     /// assert_eq!(sched.metrics.total_tx, 0);
     /// ```
     pub fn add_node(&mut self, node: Box<dyn NodeHandle>, initial_wake: Option<SimTime>) {
+        debug_assert!(
+            (0..self.interferers.len()).all(|i| node.node_id().0 != u32::MAX - i as u32),
+            "NodeId({}) collides with interferer ID space",
+            node.node_id().0
+        );
         if let Some(wake) = initial_wake {
             let node_id = node.node_id();
             self.schedule(wake, EventKind::Wake { node_id });
@@ -143,6 +148,11 @@ impl Scheduler {
 
     pub fn add_interferer(&mut self, interferer: Box<dyn InterferenceSource>, first_poll: SimTime) {
         let idx = self.interferers.len();
+        let synthetic_id = u32::MAX - idx as u32;
+        debug_assert!(
+            self.nodes.iter().all(|n| n.node_id().0 != synthetic_id),
+            "interferer synthetic NodeId({synthetic_id}) collides with a registered node"
+        );
         self.interferers.push(interferer);
         self.schedule(
             first_poll,
@@ -270,9 +280,6 @@ impl Scheduler {
                     let time = event.time;
                     if let Some(tx) = self.interferers[interferer_idx].poll_inject(time) {
                         let duration = tx.duration_us;
-                        let sf = tx.sf;
-                        let frequency = tx.frequency;
-                        let payload = tx.payload.clone();
                         let interferer_node_id = NodeId(u32::MAX - interferer_idx as u32);
                         let ch_event =
                             self.channel
@@ -288,15 +295,6 @@ impl Scheduler {
                                 sender: interferer_node_id,
                             },
                         );
-                        let frame = RxMetadata {
-                            payload,
-                            rssi: -90.0,
-                            snr: 5.0,
-                            sf,
-                            frequency,
-                            time: complete_time,
-                        };
-                        let _ = frame;
                     }
                     let next = self.interferers[interferer_idx].next_poll_time(time);
                     if let Some(t) = next {

--- a/src/time.rs
+++ b/src/time.rs
@@ -15,10 +15,10 @@ pub type SimTime = u64;
 ///
 /// ```
 /// use theatron::time::sim_time_to_ms;
-/// assert_eq!(sim_time_to_ms(5_000), 5);
+/// assert_eq!(sim_time_to_ms(5_000), 5u64);
 /// ```
-pub fn sim_time_to_ms(t: SimTime) -> u32 {
-    (t / 1_000) as u32
+pub fn sim_time_to_ms(t: SimTime) -> u64 {
+    t / 1_000
 }
 
 /// Convert milliseconds to simulation time (microseconds).
@@ -41,13 +41,19 @@ mod tests {
     #[test]
     fn zero_round_trips() {
         assert_eq!(ms_to_sim_time(0), 0);
-        assert_eq!(sim_time_to_ms(0), 0);
+        assert_eq!(sim_time_to_ms(0), 0u64);
     }
 
     #[test]
     fn one_ms_is_1000_us() {
         assert_eq!(ms_to_sim_time(1), 1_000);
-        assert_eq!(sim_time_to_ms(1_000), 1);
+        assert_eq!(sim_time_to_ms(1_000), 1u64);
+    }
+
+    #[test]
+    fn large_sim_time_no_truncation() {
+        let large_us = (u32::MAX as u64 + 1) * 1_000;
+        assert_eq!(sim_time_to_ms(large_us), u32::MAX as u64 + 1);
     }
 
     proptest! {
@@ -55,11 +61,11 @@ mod tests {
         fn ms_to_sim_and_back_is_approx(ms in 0u32..1_000_000u32) {
             let sim = ms_to_sim_time(ms);
             let back = sim_time_to_ms(sim);
-            prop_assert_eq!(back, ms);
+            prop_assert_eq!(back, ms as u64);
         }
 
         #[test]
-        fn sim_time_monotone(a in 0u64..1_000_000_000u64, b in 0u64..1_000_000_000u64) {
+        fn sim_time_monotone(a in 0u64..u64::MAX / 1_000, b in 0u64..u64::MAX / 1_000) {
             if a <= b {
                 prop_assert!(sim_time_to_ms(a) <= sim_time_to_ms(b));
             }


### PR DESCRIPTION
## Summary

Follow-up fixes from the PR #3 review (ref: issue #6 tracked separately for dead-code suppression).

- **Remove dead interference frame construction**: `InterferencePoll` was building an `RxMetadata` frame and immediately discarding it with `let _ = frame`. Removed the dead `payload`/`sf`/`frequency` extraction and frame construction entirely.
- **Remove misleading `_node_id` from `Channel::deliver_to`**: The parameter was silently ignored (all completed non-collided frames were returned regardless). Removed the parameter; updated doctest and all test call sites.
- **Guard interferer synthetic NodeId collisions**: Interferers get synthetic IDs via `NodeId(u32::MAX - idx)`. Added `debug_assert` in both `add_node` and `add_interferer` to catch cases where a real node ID collides with the interferer ID space.
- **Fix `sim_time_to_ms` silent u32 truncation**: Changed return type from `u32` to `u64`. Added `large_sim_time_no_truncation` regression test and expanded proptest range to cover values beyond `u32::MAX`.

## Test plan

- [x] `cargo test --all-features` — 30 lib + 4 integration + 3 frame correctness + 28 doctests pass
- [x] `cargo test --example lorawan_file_transfer` — 22 example unit tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] All pre-commit hooks pass