### PR TITLE
fix(deps): use lora-rs git dep to drop atomic-polyfill (RUSTSEC-2023-0089)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,12 +102,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto-common"
@@ -288,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -312,14 +297,11 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version",
- "spin",
  "stable_deref_trait",
 ]
 
@@ -393,15 +375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,36 +383,42 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "lora-modulation"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c96c4a41a1f1ad04de765306e1829c7007a37898fe4033204fa82cf2e055624"
+source = "git+https://github.com/lora-rs/lora-rs?rev=597beac2a7774bd98874f1e5abfa9ac62eface81#597beac2a7774bd98874f1e5abfa9ac62eface81"
 
 [[package]]
 name = "lorawan"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6ce62c8de171d3b75cb6046580e7b2a97ac91ebb8d8244dc1d8f7de3cbf47"
+version = "0.9.1"
+source = "git+https://github.com/lora-rs/lora-rs?rev=597beac2a7774bd98874f1e5abfa9ac62eface81#597beac2a7774bd98874f1e5abfa9ac62eface81"
 dependencies = [
  "aes",
  "cmac",
- "generic-array",
  "hex",
+ "lorawan-macros",
+ "serde",
 ]
 
 [[package]]
 name = "lorawan-device"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb0f66b5f560597f29a9a35ee35a55134d62cf58ec5164ba30cb9a3d5b8c34b"
+source = "git+https://github.com/lora-rs/lora-rs?rev=597beac2a7774bd98874f1e5abfa9ac62eface81#597beac2a7774bd98874f1e5abfa9ac62eface81"
 dependencies = [
  "document-features",
  "fastrand",
  "futures",
- "generic-array",
  "heapless",
  "lora-modulation",
  "lorawan",
  "rand_core 0.6.4",
- "seq-macro",
+]
+
+[[package]]
+name = "lorawan-macros"
+version = "0.1.0"
+source = "git+https://github.com/lora-rs/lora-rs?rev=597beac2a7774bd98874f1e5abfa9ac62eface81#597beac2a7774bd98874f1e5abfa9ac62eface81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -594,15 +573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,22 +598,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -652,6 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -685,15 +644,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ path = "examples/lorawan_file_transfer/main.rs"
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
-lorawan-device = { version = "0.12", features = ["default-crypto"] }
-lorawan = { version = "0.9", default-features = false, features = ["default-crypto"] }
-lora-modulation = "0.1"
+lorawan-device = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a7774bd98874f1e5abfa9ac62eface81" }
+lorawan = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a7774bd98874f1e5abfa9ac62eface81", package = "lorawan" }
+lora-modulation = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a7774bd98874f1e5abfa9ac62eface81" }
 proptest = "1"
 rand_core = { version = "0.6", default-features = false }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,6 @@
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = [
-    # atomic-polyfill is unmaintained; pulled in transitively by lorawan-device 0.12 via heapless 0.7.
-    # No safe upgrade is available in this dependency tree.
-    "RUSTSEC-2023-0089",
-]
 unmaintained = "all"
 
 [licenses]
@@ -44,3 +39,4 @@ multiple-versions = "warn"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/lora-rs/lora-rs"]

--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -1,4 +1,3 @@
-use lorawan_device::default_crypto::DefaultFactory;
 use lorawan_device::nb_device::radio::Event as RadioEvent;
 use lorawan_device::nb_device::{Device, Response};
 use lorawan_device::{AppSKey, DevAddr, JoinMode, NewSKey};
@@ -16,7 +15,7 @@ const BUF_SIZE: usize = 255;
 
 pub struct LoRaWanAdapter {
     id: NodeId,
-    device: Device<SimulatedRadio, DefaultFactory, Xorshift64, BUF_SIZE>,
+    device: Device<SimulatedRadio, Xorshift64, BUF_SIZE>,
     fragmenter: FileFragmenter,
     pending_timeout_ms: Option<u32>,
     tx_start_time: SimTime,
@@ -33,7 +32,7 @@ impl LoRaWanAdapter {
         let credentials = JoinMode::ABP {
             devaddr: DevAddr::from(id.0),
             appskey: AppSKey::from([id.0 as u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            newskey: NewSKey::from([id.0 as u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]),
+            nwkskey: NewSKey::from([id.0 as u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]),
         };
         device.join(credentials).expect("ABP join must succeed");
         device.set_datarate(lorawan_device::region::DR::_5);

--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -100,7 +100,7 @@ impl PhyRxTx for SimulatedRadio {
             Event::TxRequest(tx_config, buf) => {
                 let TxConfig {
                     pw,
-                    rf: RfConfig { frequency, bb },
+                    rf: RfConfig { frequency, bb, .. },
                 } = tx_config;
                 let payload = buf.to_vec();
                 let duration_us = compute_duration_us(&bb, payload.len());
@@ -156,6 +156,7 @@ mod tests {
         RfConfig {
             frequency: 868_100_000,
             bb: make_bb(),
+            max_payload_len: 255,
         }
     }
 

--- a/tests/lorawan_frame_correctness.rs
+++ b/tests/lorawan_frame_correctness.rs
@@ -1,6 +1,6 @@
+use lorawan::default_crypto::DefaultFactory;
 use lorawan::keys::AES128;
 use lorawan::parser::{DataHeader, DataPayload, MHDRAble, MType, PhyPayload};
-use lorawan_device::default_crypto::DefaultFactory;
 use lorawan_device::nb_device::radio::{Event, PhyRxTx, Response, RfConfig, RxQuality, TxConfig};
 use lorawan_device::nb_device::{Device, Event as DevEvent};
 use lorawan_device::{AppSKey, DevAddr, JoinMode, NewSKey, Timings};
@@ -86,7 +86,7 @@ impl PhyRxTx for MinimalRadio {
         match event {
             Event::TxRequest(tx_config, buf) => {
                 let TxConfig {
-                    rf: RfConfig { frequency, bb },
+                    rf: RfConfig { frequency, bb, .. },
                     ..
                 } = tx_config;
                 let payload = buf.to_vec();
@@ -129,7 +129,7 @@ const DEV_ID: u32 = 42;
 const NWK_SKEY_BYTES: [u8; 16] = [DEV_ID as u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2];
 const APP_SKEY_BYTES: [u8; 16] = [DEV_ID as u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
-fn make_device() -> Device<MinimalRadio, DefaultFactory, Xorshift64, 255> {
+fn make_device() -> Device<MinimalRadio, Xorshift64, 255> {
     let radio = MinimalRadio::new();
     let rng = Xorshift64::new(0xDEAD_BEEF);
     let region = lorawan_device::region::Configuration::new(lorawan_device::Region::EU868);
@@ -137,14 +137,14 @@ fn make_device() -> Device<MinimalRadio, DefaultFactory, Xorshift64, 255> {
     let credentials = JoinMode::ABP {
         devaddr: DevAddr::from(DEV_ID),
         appskey: AppSKey::from(APP_SKEY_BYTES),
-        newskey: NewSKey::from(NWK_SKEY_BYTES),
+        nwkskey: NewSKey::from(NWK_SKEY_BYTES),
     };
     device.join(credentials).expect("ABP join must succeed");
     device.set_datarate(lorawan_device::region::DR::_5);
     device
 }
 
-fn drain_rx_windows(device: &mut Device<MinimalRadio, DefaultFactory, Xorshift64, 255>) {
+fn drain_rx_windows(device: &mut Device<MinimalRadio, Xorshift64, 255>) {
     for _ in 0..10 {
         if device.ready_to_send_data() {
             break;
@@ -154,7 +154,7 @@ fn drain_rx_windows(device: &mut Device<MinimalRadio, DefaultFactory, Xorshift64
 }
 
 fn send_and_get_payload(
-    device: &mut Device<MinimalRadio, DefaultFactory, Xorshift64, 255>,
+    device: &mut Device<MinimalRadio, Xorshift64, 255>,
     data: &[u8],
 ) -> Vec<u8> {
     drain_rx_windows(device);
@@ -192,7 +192,7 @@ fn uplink_mic_validates() {
         let nwk_skey = AES128(NWK_SKEY_BYTES);
         let fcnt = phy.fhdr().fcnt() as u32;
         assert!(
-            phy.validate_mic(&nwk_skey, fcnt),
+            phy.validate_mic(&nwk_skey, fcnt, &DefaultFactory),
             "MIC must validate with known NwkSKey"
         );
     } else {


### PR DESCRIPTION
## Summary

- Points `lorawan-device`, `lorawan`, and `lora-modulation` at the lora-rs git commit `597beac` where heapless was bumped to 0.9 (using `portable-atomic` instead of `atomic-polyfill`)
- Removes `RUSTSEC-2023-0089` advisory ignore from `deny.toml` — `atomic-polyfill` is no longer in the dependency tree
- Allows the lora-rs git source in `deny.toml`
- Updates call sites for API changes between lorawan-device 0.12.2 and git HEAD: `Device` no longer takes a `CryptoFactory` type parameter, `JoinMode::ABP` uses `nwkskey`, `RfConfig` gained `max_payload_len`, and `validate_mic` now takes an explicit factory argument

Closes #6

## Test plan

- [x] `cargo build --examples` succeeds
- [x] `cargo test --all-features` passes (28 tests)
- [x] `cargo audit` clean — no RUSTSEC-2023-0089
- [x] `cargo deny check` passes — `atomic-polyfill` absent from `Cargo.lock`
- [x] All pre-commit hooks pass