### PR TITLE
Simplify codecov configuration and disable project coverage checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,19 +1,6 @@
 coverage:
   status:
-    project:
-      default:
-        target: 100%
-        threshold: 0%
-        if_not_found: success
-        if_ci_failed: error
-    patch:
-      default:
-        target: 100%
-        threshold: 0%
-        if_not_found: success
-        if_ci_failed: error
-
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: true
+    project: off
+  patch:
+    default:
+      target: 100%


### PR DESCRIPTION
## Summary
This PR simplifies the codecov configuration by disabling project-level coverage checks and removing comment-related settings while maintaining patch coverage requirements.

## Key Changes
- Disabled project-level coverage status checks by setting `project: off`
- Removed project coverage target (100%), threshold, and conditional settings
- Removed comment layout configuration (`reach,diff,flags,tree`)
- Removed comment behavior and `require_changes` settings
- Retained patch-level coverage target of 100% for ongoing quality standards

## Rationale
This change streamlines the codecov configuration to focus on patch-level coverage validation while reducing noise from project-wide coverage status checks and PR comments. This allows for more flexible coverage tracking without blocking PRs based on overall project metrics.

https://claude.ai/code/session_01Kb4cBdZmgnRnb76BUK8W6G