### PR TITLE
Fix broken example tests, inline trivial wrappers

### DIFF
--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -60,18 +60,6 @@ impl Default for SimulatedRadio {
     }
 }
 
-fn sf_to_u8(sf: SpreadingFactor) -> u8 {
-    sf.factor() as u8
-}
-
-fn bw_to_u32(bw: Bandwidth) -> u32 {
-    bw.hz()
-}
-
-fn cr_to_u8(cr: CodingRate) -> u8 {
-    cr.denom() as u8
-}
-
 fn compute_duration_us(bb: &BaseBandModulationParams, payload_len: usize) -> u64 {
     bb.time_on_air_us(Some(8), true, payload_len as u8) as u64
 }
@@ -106,9 +94,9 @@ impl PhyRxTx for SimulatedRadio {
                 let duration_us = compute_duration_us(&bb, payload.len());
                 self.pending_tx = Some(Transmission {
                     payload,
-                    sf: sf_to_u8(bb.sf),
-                    bandwidth: bw_to_u32(bb.bw),
-                    coding_rate: cr_to_u8(bb.cr),
+                    sf: bb.sf.factor() as u8,
+                    bandwidth: bb.bw.hz(),
+                    coding_rate: bb.cr.denom() as u8,
                     frequency,
                     duration_us,
                     tx_power_dbm: pw,
@@ -173,9 +161,18 @@ mod tests {
     }
 
     #[test]
+    fn inject_downlink_requires_rx_mode() {
+        let mut radio = SimulatedRadio::new();
+        // Without entering RX mode, inject_downlink should return false
+        assert!(!radio.inject_downlink(vec![0x01, 0x02, 0x03], 7, 868_100_000));
+    }
+
+    #[test]
     fn inject_downlink_populates_rx_buf() {
         let mut radio = SimulatedRadio::new();
-        radio.inject_downlink(vec![0x01, 0x02, 0x03]);
+        // Enter RX mode first
+        let _ = radio.handle_event(Event::RxRequest(make_rf()));
+        assert!(radio.inject_downlink(vec![0x01, 0x02, 0x03], 7, 868_100_000));
         assert_eq!(radio.get_received_packet(), &[0x01, 0x02, 0x03]);
     }
 
@@ -207,7 +204,9 @@ mod tests {
     #[test]
     fn phy_with_downlink_returns_rx_done() {
         let mut radio = SimulatedRadio::new();
-        radio.inject_downlink(vec![0xAB]);
+        // Enter RX mode and inject downlink
+        let _ = radio.handle_event(Event::RxRequest(make_rf()));
+        radio.inject_downlink(vec![0xAB], 7, 868_100_000);
         let result = radio.handle_event(Event::Phy(()));
         assert!(matches!(result, Ok(Response::RxDone(_))));
     }
@@ -223,6 +222,6 @@ mod tests {
     fn timings_values() {
         let radio = SimulatedRadio::new();
         assert_eq!(radio.get_rx_window_offset_ms(), 0);
-        assert_eq!(radio.get_rx_window_duration_ms(), 100);
+        assert_eq!(radio.get_rx_window_duration_ms(), 1000);
     }
 }

--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -136,13 +136,16 @@ impl Timings for SimulatedRadio {
 mod tests {
     use super::*;
 
+    const TEST_SF: u8 = 7;
+    const TEST_FREQ: u32 = 868_100_000;
+
     fn make_bb() -> BaseBandModulationParams {
         BaseBandModulationParams::new(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5)
     }
 
     fn make_rf() -> RfConfig {
         RfConfig {
-            frequency: 868_100_000,
+            frequency: TEST_FREQ,
             bb: make_bb(),
             max_payload_len: 255,
         }
@@ -164,7 +167,7 @@ mod tests {
     fn inject_downlink_requires_rx_mode() {
         let mut radio = SimulatedRadio::new();
         // Without entering RX mode, inject_downlink should return false
-        assert!(!radio.inject_downlink(vec![0x01, 0x02, 0x03], 7, 868_100_000));
+        assert!(!radio.inject_downlink(vec![0x01, 0x02, 0x03], TEST_SF, TEST_FREQ));
     }
 
     #[test]
@@ -172,7 +175,7 @@ mod tests {
         let mut radio = SimulatedRadio::new();
         // Enter RX mode first
         let _ = radio.handle_event(Event::RxRequest(make_rf()));
-        assert!(radio.inject_downlink(vec![0x01, 0x02, 0x03], 7, 868_100_000));
+        assert!(radio.inject_downlink(vec![0x01, 0x02, 0x03], TEST_SF, TEST_FREQ));
         assert_eq!(radio.get_received_packet(), &[0x01, 0x02, 0x03]);
     }
 
@@ -187,8 +190,8 @@ mod tests {
         let result = radio.handle_event(Event::TxRequest(tx_config, &payload));
         assert!(result.is_ok());
         let tx = radio.take_pending_tx().expect("should have pending tx");
-        assert_eq!(tx.sf, 7);
-        assert_eq!(tx.frequency, 868_100_000);
+        assert_eq!(tx.sf, TEST_SF);
+        assert_eq!(tx.frequency, TEST_FREQ);
         assert_eq!(tx.payload, &[0x01, 0x02, 0x03]);
     }
 
@@ -206,7 +209,7 @@ mod tests {
         let mut radio = SimulatedRadio::new();
         // Enter RX mode and inject downlink
         let _ = radio.handle_event(Event::RxRequest(make_rf()));
-        radio.inject_downlink(vec![0xAB], 7, 868_100_000);
+        assert!(radio.inject_downlink(vec![0xAB], TEST_SF, TEST_FREQ));
         let result = radio.handle_event(Event::Phy(()));
         assert!(matches!(result, Ok(Response::RxDone(_))));
     }


### PR DESCRIPTION
The `#[cfg(test)]` block in `examples/lorawan_file_transfer/simulated_radio.rs` contains tests that would fail to compile if they were ever executed:

1. **`inject_downlink_populates_rx_buf`**: calls `inject_downlink(vec![...])` with 1 argument, but the method requires 3 (`data`, `sf`, `frequency`). Additionally, `inject_downlink` requires the radio to be in RX mode first, which the test did not set up.
2. **`timings_values`**: asserted `get_rx_window_duration_ms() == 100` but the `RX_WINDOW_DURATION_MS` constant is `1000`.

These tests are silently dead code because `#[cfg(test)]` blocks inside example binaries are never compiled or run by `cargo test`. The fixes here are correctness-proofing them for a future move to `tests/` — they remain dead code in the current structure.

## Changes

- Fixed `inject_downlink_populates_rx_buf` to pass all 3 required arguments and enter RX mode first
- Added `inject_downlink_requires_rx_mode` test covering the guard-false path
- Fixed `timings_values` to assert the correct constant value (1000)
- Fixed `phy_with_downlink_returns_rx_done` to enter RX mode before injecting, and assert the return value of `inject_downlink`
- Inlined trivial one-liner conversion functions `sf_to_u8`, `bw_to_u32`, `cr_to_u8` — each just called `.factor()`, `.hz()`, or `.denom()` and cast, adding indirection without clarity
- Extracted `TEST_SF` and `TEST_FREQ` constants in the test module so the magic literals `7` and `868_100_000` stay in sync with `make_rf()`

## Test plan

- Example tests now match the actual API and would compile/pass if executed
- No production behavior change — only example test code was modified

## Note on dead code

`#[cfg(test)]` blocks inside example binaries are never compiled or run by `cargo test`. A follow-up task to move these tests to `tests/simulated_radio.rs` would make them live. This PR is scoped to correctness-proofing them in place.