### PR TITLE
docs: configure badges like marigold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# theatron
+# Theatron
 
 [![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
-[![license](https://img.shields.io/crates/l/theatron.svg)](https://github.com/DominicBurkart/theatron)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
 
 Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# theatron
+
+[![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
+[![license](https://img.shields.io/crates/l/theatron.svg)](https://github.com/DominicBurkart/theatron)
+[![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
+
+Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
-[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron/blob/main/LICENSE-MIT)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
 
 Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.


### PR DESCRIPTION
## Summary\n\n- Adds README.md with badges matching marigold's style (closes #13)\n- Badges included: CI status, codecov coverage, license, last commit\n- Only badges for services that are actually configured in the repo were added\n\n## Badge mapping from marigold\n\n| Marigold badge | Theatron | Notes |\n|---|---|---|\n| crates.io | skipped | not published yet |\n| docs.rs | skipped | not published yet |\n| website | skipped | no website |\n| lines of code | skipped | no development_metadata setup |\n| contributors | skipped | no development_metadata setup |\n| bench | skipped | no bench workflow |\n| tests / style / wasm | CI | single CI workflow covers fmt, clippy, test |\n| onboarding | skipped | no onboarding workflow |\n| last commit | included | |\n| codecov | included | codecov.yml + coverage job in CI |\n| license | included | MIT OR Apache-2.0 |\n\nhttps://claude.ai/code/session_016LGnihh2HtPWjxCwUsU9Mz"