### PR TITLE
feat: implement Pure ALOHA reference protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/main.rs"
 name = "lorawan_file_transfer"
 path = "examples/lorawan_file_transfer/main.rs"
 
+[[example]]
+name = "aloha"
+path = "examples/aloha/main.rs"
+
 [dependencies]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ name = "aloha"
 path = "examples/aloha/main.rs"
 
 [dependencies]
+rand_core = { version = "0.6", default-features = false, optional = true } # optional; see [features] below
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
@@ -30,8 +31,11 @@ lorawan-device = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a7
 lorawan = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a7774bd98874f1e5abfa9ac62eface81", package = "lorawan" }
 lora-modulation = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a7774bd98874f1e5abfa9ac62eface81" }
 proptest = "1"
-rand_core = { version = "0.6", default-features = false }
 
 [profile.release]
 lto = true
 codegen-units = 1
+
+[features]
+default = ["prng"]
+prng = ["rand_core"]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
 coverage:
   status:
-    project: off
-  patch:
-    default:
-      target: 100%
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: 100%

--- a/examples/aloha/main.rs
+++ b/examples/aloha/main.rs
@@ -6,7 +6,7 @@
 //! Run with:
 //!   cargo run --example aloha
 
-use theatron::aloha::{AlohaNode, PoissonTraffic, LORA_SF7_DURATION_US};
+use theatron::aloha::{AlohaNode, UniformInterarrivalTraffic, LORA_SF7_DURATION_US};
 use theatron::scheduler::Scheduler;
 use theatron::types::NodeId;
 
@@ -30,7 +30,7 @@ fn main() {
     ];
 
     for (id, traffic_seed, backoff_seed) in nodes {
-        let traffic = PoissonTraffic::new(MEAN_INTER_ARRIVAL_US, traffic_seed);
+        let traffic = UniformInterarrivalTraffic::new(MEAN_INTER_ARRIVAL_US, traffic_seed);
         let node = AlohaNode::new(NodeId(id), traffic, BACKOFF_RANGE_US, backoff_seed);
         scheduler.add_node(Box::new(node), Some(0));
     }

--- a/examples/aloha/main.rs
+++ b/examples/aloha/main.rs
@@ -1,0 +1,55 @@
+//! Pure ALOHA simulation example.
+//!
+//! Runs three ALOHA nodes at ~0.1 packets/s for 10 seconds and prints
+//! aggregate statistics.
+//!
+//! Run with:
+//!   cargo run --example aloha
+
+use theatron::aloha::{AlohaNode, PoissonTraffic, LORA_SF7_DURATION_US};
+use theatron::scheduler::Scheduler;
+use theatron::types::NodeId;
+
+/// Mean inter-arrival time for ~0.1 pkt/s = 10 s = 10_000_000 µs.
+const MEAN_INTER_ARRIVAL_US: u64 = 10_000_000;
+
+/// Backoff window: up to 2× the packet duration.
+const BACKOFF_RANGE_US: u64 = LORA_SF7_DURATION_US * 2;
+
+/// Simulation duration: 10 seconds.
+const SIM_DURATION_US: u64 = 10_000_000;
+
+fn main() {
+    let mut scheduler = Scheduler::new(SIM_DURATION_US);
+
+    // Three ALOHA nodes with different RNG seeds for independence.
+    let nodes: [(u32, u64, u64); 3] = [
+        (1, 0xDEAD_BEEF_0000_0001, 0xCAFE_BABE_0000_0001),
+        (2, 0xDEAD_BEEF_0000_0002, 0xCAFE_BABE_0000_0002),
+        (3, 0xDEAD_BEEF_0000_0003, 0xCAFE_BABE_0000_0003),
+    ];
+
+    for (id, traffic_seed, backoff_seed) in nodes {
+        let traffic = PoissonTraffic::new(MEAN_INTER_ARRIVAL_US, traffic_seed);
+        let node = AlohaNode::new(NodeId(id), traffic, BACKOFF_RANGE_US, backoff_seed);
+        scheduler.add_node(Box::new(node), Some(0));
+    }
+
+    println!(
+        "Running Pure ALOHA simulation ({} nodes, {:.1}s)...",
+        3,
+        SIM_DURATION_US as f64 / 1_000_000.0
+    );
+
+    scheduler.run();
+
+    let m = &scheduler.metrics;
+    let sim_s = SIM_DURATION_US as f64 / 1_000_000.0;
+    let throughput = m.total_rx as f64 / sim_s;
+
+    println!("Simulation complete at t={}us", scheduler.current_time());
+    println!("  Total TX:         {}", m.total_tx);
+    println!("  Total RX:         {}", m.total_rx);
+    println!("  Total collisions: {}", m.total_collisions);
+    println!("  Throughput:       {:.4} pkt/s", throughput);
+}

--- a/src/aloha.rs
+++ b/src/aloha.rs
@@ -526,4 +526,93 @@ mod tests {
             LORA_SF7_DURATION_US
         );
     }
+
+    /// Calling `poll_transmit` while the node is in `Idle` phase must return
+    /// `None` — the guard at the top of `poll_transmit` covers this path.
+    #[test]
+    fn poll_transmit_returns_none_when_not_ready() {
+        let mut node = AlohaNode::new(NodeId(5), NeverFire, 0, 1);
+        // Node starts in Idle — poll_transmit must return None.
+        assert!(
+            node.poll_transmit(0).is_none(),
+            "poll_transmit must return None when not in ReadyToTransmit"
+        );
+    }
+
+    /// Calling `update` a second time while already in `ReadyToTransmit`
+    /// (without an intervening `poll_transmit`) must return `Some(time)` and
+    /// leave the payload intact.
+    #[test]
+    fn update_returns_same_time_when_ready_to_transmit() {
+        let traffic = OneShot(Some(vec![0xFF]));
+        let mut node = AlohaNode::new(NodeId(6), traffic, 0, 2);
+        // First update: traffic fires → phase becomes ReadyToTransmit.
+        let t1 = node.update(0);
+        assert_eq!(t1, Some(0), "should wake immediately when ready");
+        // Second update (still in ReadyToTransmit, poll_transmit not yet called).
+        let t2 = node.update(0);
+        assert_eq!(
+            t2,
+            Some(0),
+            "update while ReadyToTransmit must return the same time"
+        );
+        // Payload must still be available.
+        assert!(
+            node.poll_transmit(0).is_some(),
+            "payload must survive the extra update call"
+        );
+    }
+
+    /// Calling `update` with a time strictly before the backoff deadline must
+    /// return `Some(until)` without advancing the phase — the "still waiting"
+    /// path inside `Phase::Backoff`.
+    #[test]
+    fn backoff_still_waiting_returns_future_wake() {
+        let traffic = OneShot(Some(vec![0x42]));
+        // backoff_range_us = 100_000 → backoff ∈ [0, 100_000)
+        let mut node = AlohaNode::new(NodeId(7), traffic, 100_000, 3);
+
+        // Drive to ReadyToTransmit.
+        node.update(0);
+        // Transmit: phase → AwaitingBackoffStart.
+        let tx = node.poll_transmit(0);
+        assert!(tx.is_some());
+
+        // update at t=0: phase → Backoff { until = 0 + 56_000 + backoff }.
+        let until = node.update(0).expect("must return the backoff deadline");
+        assert!(until >= LORA_SF7_DURATION_US, "deadline must be after on-air time");
+
+        // Call update with time strictly before the deadline.
+        let mid = until / 2;
+        let again = node.update(mid);
+        assert_eq!(
+            again,
+            Some(until),
+            "still-waiting path must return the original deadline"
+        );
+    }
+
+    /// `on_receive` is a no-op for Pure ALOHA; it must return `None` and not
+    /// mutate the node state.
+    #[test]
+    fn on_receive_returns_none() {
+        let mut node = AlohaNode::new(NodeId(8), NeverFire, 0, 1);
+        let frame = RxMetadata {
+            payload: vec![0xDE, 0xAD],
+            rssi: -90.0,
+            snr: 5.0,
+            sf: 7,
+            frequency: LORA_FREQUENCY,
+            time: 0,
+        };
+        assert!(
+            node.on_receive(frame, 0).is_none(),
+            "Pure ALOHA on_receive must always return None"
+        );
+        // Node must still be idle after the receive event.
+        assert!(
+            node.poll_transmit(0).is_none(),
+            "on_receive must not trigger a transmission"
+        );
+    }
 }

--- a/src/aloha.rs
+++ b/src/aloha.rs
@@ -1,0 +1,336 @@
+//! Pure ALOHA reference MAC protocol.
+//!
+//! Nodes transmit immediately whenever the traffic model produces a payload.
+//! After each transmission (successful or not), a random backoff is drawn from
+//! `U(0, backoff_range_us)` before the next transmission attempt, giving the
+//! channel time to clear and preventing correlated retransmissions.
+//!
+//! # Example
+//!
+//! ```
+//! use theatron::aloha::{AlohaNode, PoissonTraffic};
+//! use theatron::scheduler::{NodeHandle, Scheduler};
+//! use theatron::types::NodeId;
+//!
+//! let traffic = PoissonTraffic::new(10_000_000, 0xDEAD_BEEF);
+//! let node = AlohaNode::new(NodeId(1), traffic, 2_000_000, 0xCAFE_BABE);
+//! let mut scheduler = Scheduler::new(10_000_000);
+//! scheduler.add_node(Box::new(node), Some(0));
+//! scheduler.run();
+//! ```
+
+use crate::scheduler::NodeHandle;
+use crate::time::SimTime;
+use crate::traits::TrafficModel;
+use crate::types::{NodeId, RxMetadata, Transmission};
+
+// LoRa SF7/BW125 time-on-air for a minimal payload (≈56 ms).
+pub const LORA_SF7_DURATION_US: u64 = 56_000;
+pub const LORA_FREQUENCY: u32 = 868_100_000;
+pub const LORA_TX_POWER_DBM: i8 = 14;
+
+// ---------------------------------------------------------------------------
+// Minimal self-contained xorshift64 PRNG (no external deps required).
+// ---------------------------------------------------------------------------
+
+/// A fast, deterministic pseudo-random number generator based on xorshift64.
+///
+/// Used internally by [`AlohaNode`] and [`PoissonTraffic`] so that the module
+/// has no dependencies beyond `std`.
+#[derive(Clone)]
+pub struct Xorshift64(u64);
+
+impl Xorshift64 {
+    /// Create a new PRNG seeded with `seed`.  A seed of `0` is replaced by `1`
+    /// to avoid the all-zero fixed point.
+    pub fn new(seed: u64) -> Self {
+        Self(if seed == 0 { 1 } else { seed })
+    }
+
+    /// Return the next pseudo-random `u64`.
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    /// Return a value uniformly distributed in `[0, range)`.
+    ///
+    /// Uses rejection sampling to avoid modulo bias; for ranges that are a
+    /// small fraction of `u64::MAX` this is effectively a single draw.
+    pub fn next_u64_below(&mut self, range: u64) -> u64 {
+        if range == 0 {
+            return 0;
+        }
+        // Rejection sampling: discard values in the biased tail.
+        let threshold = u64::MAX - (u64::MAX % range);
+        loop {
+            let v = self.next_u64();
+            if v < threshold {
+                return v % range;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PoissonTraffic — exponentially-distributed inter-arrival times.
+// ---------------------------------------------------------------------------
+
+/// A [`TrafficModel`] that generates packet arrivals according to a Poisson
+/// process with a given mean inter-arrival time.
+///
+/// Each call to [`next_payload`][TrafficModel::next_payload] either returns a
+/// one-byte payload (when the elapsed time since the last arrival exceeds the
+/// next drawn inter-arrival interval) or `None`.
+///
+/// # Example
+///
+/// ```
+/// use theatron::aloha::PoissonTraffic;
+/// use theatron::traits::TrafficModel;
+///
+/// let mut traffic = PoissonTraffic::new(1_000_000, 42);
+/// // At time 0 the node hasn't started yet; first call schedules next arrival.
+/// let _ = traffic.next_payload(0);
+/// ```
+pub struct PoissonTraffic {
+    mean_us: u64,
+    rng: Xorshift64,
+    next_arrival_us: Option<SimTime>,
+}
+
+impl PoissonTraffic {
+    /// Create a new Poisson traffic model.
+    ///
+    /// * `mean_us` — mean inter-arrival time in microseconds.
+    /// * `seed`    — PRNG seed for reproducibility.
+    pub fn new(mean_us: u64, seed: u64) -> Self {
+        Self {
+            mean_us,
+            rng: Xorshift64::new(seed),
+            next_arrival_us: None,
+        }
+    }
+
+    /// Draw an exponentially-distributed inter-arrival delay (µs).
+    ///
+    /// Uses the inverse-CDF transform: `delay = -mean * ln(U)` where `U` is
+    /// uniform in `(0, 1]`.  To stay in integer arithmetic we approximate with
+    /// a geometric distribution: `delay = mean * (number of Bernoulli trials
+    /// until first success with p=1/mean)`.  For simplicity we use the
+    /// well-known approximation `delay ≈ -mean * ln(u / 2^64)` evaluated with
+    /// fixed-point: we draw a random `u64` and compute
+    /// `delay = mean * leading_zeros_weight`.
+    ///
+    /// In practice for a simulator this simple geometric approximation is
+    /// sufficient; the distribution is still memoryless.
+    fn draw_interval(&mut self) -> u64 {
+        // Geometric approximation: repeatedly check each bit of a u64 word.
+        // Each bit is independently 0 with probability 1/2, so the number of
+        // leading zeros of a random u64 is geometrically distributed with
+        // p=0.5.  We scale to the desired mean by tossing `mean_us` trials
+        // of a 1-bit coin, which gives a geometric with mean = 2*mean_us.
+        // Instead, we use the standard approximation:
+        //   interval ≈ mean * geometric(p = 1/mean)
+        // implemented as: sum up 1s until the first 0 in a stream of bits
+        // from our RNG, but scaled so that on average we get mean_us.
+        //
+        // Simpler correct approach: use fixed-point log approximation.
+        // We compute: interval = round(-mean * ln(v)) where v = (raw+1)/2^64.
+        // ln approximation via bit-length: ln(v) ≈ -(63 - floor(log2(raw+1))).
+        // This is crude; instead we use a rejection-free geometric:
+        //   Draw bits until we see the first 1; count of 0s = k.
+        //   P(k=n) = (1/2)^(n+1).  Mean k = 1.
+        //   So interval = mean_us * (k+1) gives mean = 2*mean_us — not right.
+        //
+        // Cleanest no-float approach: just use mean_us directly as a fixed
+        // interval with a small random jitter in [0, 2*mean_us).  This gives
+        // uniform inter-arrivals with the correct mean and is reproducible.
+        // For a reference ALOHA implementation the exact distribution shape
+        // matters less than having a nonzero, non-degenerate arrival process.
+        //
+        // Final choice: uniform in [mean_us/2, 3*mean_us/2) → mean = mean_us.
+        let half = self.mean_us / 2;
+        let range = self.mean_us; // width of the uniform window
+        half + self.rng.next_u64_below(range.max(1))
+    }
+}
+
+impl TrafficModel for PoissonTraffic {
+    fn next_payload(&mut self, time: SimTime) -> Option<Vec<u8>> {
+        match self.next_arrival_us {
+            None => {
+                // First call: schedule the first arrival relative to now.
+                let interval = self.draw_interval();
+                self.next_arrival_us = Some(time + interval);
+                None
+            }
+            Some(next) if time >= next => {
+                // Payload ready — schedule the following arrival.
+                let interval = self.draw_interval();
+                self.next_arrival_us = Some(time + interval);
+                Some(vec![0x01])
+            }
+            Some(_) => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AlohaNode
+// ---------------------------------------------------------------------------
+
+/// State machine phases for an ALOHA node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AlohaPhase {
+    /// Idle: polling traffic model on each wake.
+    Idle,
+    /// Waiting for ongoing backoff to expire before polling again.
+    Backoff { until: SimTime },
+    /// A payload is ready; it will be handed to the scheduler on the next
+    /// `poll_transmit` call.
+    ReadyToTransmit,
+}
+
+/// A Pure ALOHA node.
+///
+/// On each wake the node checks its traffic model.  When a payload is
+/// produced the node marks itself `ReadyToTransmit`; the scheduler then
+/// calls `poll_transmit` and the packet goes on air immediately.  After
+/// every transmission a random backoff is inserted before the next
+/// traffic-model poll.
+///
+/// # Example
+///
+/// ```
+/// use theatron::aloha::{AlohaNode, PoissonTraffic};
+/// use theatron::scheduler::NodeHandle;
+/// use theatron::types::NodeId;
+///
+/// let traffic = PoissonTraffic::new(5_000_000, 1);
+/// let node = AlohaNode::new(NodeId(42), traffic, 500_000, 2);
+/// ```
+pub struct AlohaNode<T: TrafficModel> {
+    id: NodeId,
+    traffic: T,
+    backoff_range_us: u64,
+    rng: Xorshift64,
+    phase: AlohaPhase,
+    pending_payload: Option<Vec<u8>>,
+    /// How many µs after waking should `update` request the next wake?
+    next_poll_delay: u64,
+}
+
+impl<T: TrafficModel> AlohaNode<T> {
+    /// Create a new ALOHA node.
+    ///
+    /// * `id`               — unique node identifier.
+    /// * `traffic`          — traffic model that generates payloads.
+    /// * `backoff_range_us` — upper bound of the uniform backoff window (µs).
+    /// * `seed`             — PRNG seed for the backoff RNG.
+    pub fn new(id: NodeId, traffic: T, backoff_range_us: u64, seed: u64) -> Self {
+        Self {
+            id,
+            traffic,
+            backoff_range_us,
+            rng: Xorshift64::new(seed),
+            phase: AlohaPhase::Idle,
+            pending_payload: None,
+            // Poll the traffic model every 1 ms when idle.
+            next_poll_delay: 1_000,
+        }
+    }
+
+    /// Draw a random backoff duration in `[0, backoff_range_us)`.
+    fn draw_backoff(&mut self) -> u64 {
+        self.rng.next_u64_below(self.backoff_range_us.max(1))
+    }
+}
+
+impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+
+    /// Called by the scheduler when this node wakes up.
+    ///
+    /// Returns the next wake time or `None` if the node has nothing pending.
+    fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        match &self.phase.clone() {
+            AlohaPhase::Backoff { until } => {
+                if time >= *until {
+                    // Backoff expired — go back to idle polling.
+                    self.phase = AlohaPhase::Idle;
+                    // Fall through to idle handling below.
+                } else {
+                    // Still in backoff; wake again when it expires.
+                    return Some(*until);
+                }
+            }
+            AlohaPhase::ReadyToTransmit => {
+                // poll_transmit will pick up the payload; stay in this phase
+                // until poll_transmit clears it.  Return soon so the scheduler
+                // can call poll_transmit.
+                return Some(time + 1);
+            }
+            AlohaPhase::Idle => {}
+        }
+
+        // Idle: ask the traffic model for a payload.
+        let payload = self.traffic.next_payload(time);
+        if let Some(p) = payload {
+            self.pending_payload = Some(p);
+            self.phase = AlohaPhase::ReadyToTransmit;
+            // Wake immediately so poll_transmit is called right away.
+            Some(time)
+        } else {
+            // Nothing yet — poll again after next_poll_delay.
+            Some(time + self.next_poll_delay)
+        }
+    }
+
+    /// Called by the scheduler immediately after `update` returns.
+    ///
+    /// If a payload is ready, returns a `Transmission` and enters backoff.
+    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+        if self.phase != AlohaPhase::ReadyToTransmit {
+            return None;
+        }
+        let payload = self.pending_payload.take()?;
+        // Transition: after transmitting, always back off.
+        let backoff = self.draw_backoff();
+        // We don't know the exact current time in poll_transmit, but the
+        // scheduler will call update next with the post-TX time; we store a
+        // relative backoff that will be applied in the next update call.
+        // To pass the backoff duration to update we temporarily encode it
+        // in the Backoff phase with a sentinel: `until = backoff` (relative).
+        // update() will detect that until < time and treat it as expired,
+        // so we add a large offset.  Better: store a pending_backoff field.
+        // We use a dedicated field for clarity.
+        self.phase = AlohaPhase::Backoff {
+            until: u64::MAX, // placeholder; fixed up in on_receive or next update
+        };
+        self.pending_backoff_duration = backoff;
+        Some(Transmission {
+            payload,
+            sf: 7,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency: LORA_FREQUENCY,
+            duration_us: LORA_SF7_DURATION_US,
+            tx_power_dbm: LORA_TX_POWER_DBM,
+        })
+    }
+
+    /// Called when a frame is received from another node.
+    ///
+    /// Pure ALOHA has no carrier sense, so received frames do not affect
+    /// the transmit schedule.
+    fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+        None
+    }
+}

--- a/src/aloha.rs
+++ b/src/aloha.rs
@@ -17,10 +17,11 @@
 //!    pending backoff duration.  Because `poll_transmit` does not receive the
 //!    current time, the *absolute* backoff deadline is computed in the next
 //!    `update` call once the post-TX time is known.
-//! 4. On re-wake after the TX completes, `update` sees `pending_backoff_us`,
-//!    computes `until = time + pending_backoff_us`, enters `Backoff { until }`,
-//!    and returns `Some(until)` so the scheduler wakes the node at the right
-//!    moment.
+//! 4. On re-wake after the TX is initiated, `update` sees `pending_backoff_us`,
+//!    computes `until = time + LORA_SF7_DURATION_US + pending_backoff_us`
+//!    (ensuring the backoff guard covers the full on-air time), enters
+//!    `Backoff { until }`, and returns `Some(until)` so the scheduler wakes
+//!    the node at the right moment.
 //!
 //! # Example
 //!
@@ -187,7 +188,7 @@ enum Phase {
     ReadyToTransmit,
     /// `poll_transmit` has been called and the TX is on air; the *next*
     /// `update` call will compute the absolute backoff deadline from the
-    /// stored relative duration.
+    /// stored relative duration plus the on-air guard time.
     AwaitingBackoffStart { duration_us: u64 },
 }
 
@@ -204,7 +205,7 @@ enum Phase {
 ///   │                             │
 ///   │                     next update(time) call
 ///   │                             │
-///   │                   Backoff { until = time + duration_us }
+///   │         Backoff { until = time + LORA_SF7_DURATION_US + duration_us }
 ///   │                             │
 ///   └──────(until reached)────────┘
 /// ```
@@ -267,8 +268,12 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
     fn update(&mut self, time: SimTime) -> Option<SimTime> {
         match self.phase.clone() {
             // ── Backoff just started; now we know the current time. ──────────
+            //
+            // Add the on-air guard (LORA_SF7_DURATION_US) so the node always
+            // waits at least one full TX duration before re-attempting,
+            // regardless of the drawn backoff value.
             Phase::AwaitingBackoffStart { duration_us } => {
-                let until = time + duration_us;
+                let until = time + LORA_SF7_DURATION_US + duration_us;
                 self.phase = Phase::Backoff { until };
                 return Some(until);
             }
@@ -510,11 +515,15 @@ mod tests {
             time = next.unwrap_or(time + 1_000);
         }
         assert_eq!(tx_times.len(), 2, "should see exactly 2 transmissions");
-        // After the first TX the node enters backoff, so the second TX must be
-        // at least the TX duration later (backoff ≥ 0 but TX itself takes time).
+        // After the first TX the node enters backoff (minimum = LORA_SF7_DURATION_US),
+        // so the second TX must be at least one TX duration after the first.
         assert!(
-            tx_times[1] > tx_times[0],
-            "second TX must come after first TX"
+            tx_times[1] >= tx_times[0] + LORA_SF7_DURATION_US,
+            "second TX must be at least one TX-duration after the first; \
+             first={} second={} duration={}",
+            tx_times[0],
+            tx_times[1],
+            LORA_SF7_DURATION_US
         );
     }
 }

--- a/src/aloha.rs
+++ b/src/aloha.rs
@@ -26,23 +26,31 @@
 //! # Example
 //!
 //! ```
-//! use theatron::aloha::{AlohaNode, PoissonTraffic};
+//! use theatron::aloha::{AlohaNode, UniformInterarrivalTraffic};
 //! use theatron::scheduler::{NodeHandle, Scheduler};
 //! use theatron::types::NodeId;
 //!
-//! let traffic = PoissonTraffic::new(10_000_000, 0xDEAD_BEEF);
+//! let traffic = UniformInterarrivalTraffic::new(10_000_000, 0xDEAD_BEEF);
 //! let node = AlohaNode::new(NodeId(1), traffic, 2_000_000, 0xCAFE_BABE);
 //! let mut scheduler = Scheduler::new(10_000_000);
 //! scheduler.add_node(Box::new(node), Some(0));
 //! scheduler.run();
 //! ```
 
+use std::mem;
+
 use crate::scheduler::NodeHandle;
 use crate::time::SimTime;
 use crate::traits::TrafficModel;
 use crate::types::{NodeId, RxMetadata, Transmission};
 
-/// LoRa SF7 / BW125 time-on-air for a minimal payload (~56 ms).
+/// LoRa SF7 / BW125 time-on-air for a 1-byte payload with no explicit header
+/// (CR 4/5, preamble 8 symbols ≈ 56.6 ms, rounded to 56 ms).
+///
+/// Note: this constant is only accurate for single-byte payloads.  Larger
+/// payloads increase time-on-air significantly (e.g. a 51-byte payload at
+/// SF7/BW125 is approximately 200 ms).  Do not use this constant as a
+/// general LoRa SF7 air-time budget without adjusting for payload size.
 pub const LORA_SF7_DURATION_US: u64 = 56_000;
 /// EU868 primary uplink frequency (Hz).
 pub const LORA_FREQUENCY: u32 = 868_100_000;
@@ -55,8 +63,8 @@ pub const LORA_TX_POWER_DBM: i8 = 14;
 
 /// A fast, deterministic xorshift64 PRNG.
 ///
-/// Used by both [`PoissonTraffic`] and [`AlohaNode`] so the module requires no
-/// dependencies beyond `std`.
+/// Used by both [`UniformInterarrivalTraffic`] and [`AlohaNode`] so the module
+/// requires no dependencies beyond `std`.
 ///
 /// # Example
 ///
@@ -105,33 +113,43 @@ impl Xorshift64 {
 }
 
 // ---------------------------------------------------------------------------
-// PoissonTraffic
+// UniformInterarrivalTraffic
 // ---------------------------------------------------------------------------
 
-/// A [`TrafficModel`] that approximates Poisson packet arrivals.
+/// A [`TrafficModel`] with uniform inter-arrival times centred on `mean_us`.
 ///
-/// Inter-arrival times are drawn from a uniform distribution centred on
-/// `mean_us` — i.e. `U(mean_us/2, 3·mean_us/2)` — giving the correct mean
-/// while staying entirely in integer arithmetic.
+/// Inter-arrival times are drawn from `U(mean_us/2, 3·mean_us/2)`, giving the
+/// correct mean while staying entirely in integer arithmetic.
+///
+/// ## Note on naming
+///
+/// Despite the historic name, this distribution is **uniform**, not Poisson.
+/// A true Poisson process has exponentially-distributed inter-arrival times
+/// with an unbounded tail; this model has finite support `[mean/2, 3·mean/2)`
+/// and will never produce long quiet periods or rapid bursts.  The difference
+/// matters when using this as a Poisson baseline for collision analysis.
+/// The deprecated type alias [`PoissonTraffic`] is kept for backward
+/// compatibility but new code should use `UniformInterarrivalTraffic`
+/// directly.
 ///
 /// # Example
 ///
 /// ```
-/// use theatron::aloha::PoissonTraffic;
+/// use theatron::aloha::UniformInterarrivalTraffic;
 /// use theatron::traits::TrafficModel;
 ///
-/// let mut traffic = PoissonTraffic::new(1_000_000, 42);
+/// let mut traffic = UniformInterarrivalTraffic::new(1_000_000, 42);
 /// // First call at time 0 schedules the first arrival; returns None.
 /// assert!(traffic.next_payload(0).is_none());
 /// ```
-pub struct PoissonTraffic {
+pub struct UniformInterarrivalTraffic {
     mean_us: u64,
     rng: Xorshift64,
     /// Absolute simulation time at which the next packet arrives.
     next_arrival_us: Option<SimTime>,
 }
 
-impl PoissonTraffic {
+impl UniformInterarrivalTraffic {
     /// Create a new traffic model.
     ///
     /// * `mean_us` — mean inter-arrival time in microseconds.
@@ -153,7 +171,7 @@ impl PoissonTraffic {
     }
 }
 
-impl TrafficModel for PoissonTraffic {
+impl TrafficModel for UniformInterarrivalTraffic {
     fn next_payload(&mut self, time: SimTime) -> Option<Vec<u8>> {
         match self.next_arrival_us {
             None => {
@@ -173,6 +191,14 @@ impl TrafficModel for PoissonTraffic {
     }
 }
 
+/// Deprecated alias for [`UniformInterarrivalTraffic`].
+///
+/// The name `PoissonTraffic` is misleading because the inter-arrival
+/// distribution is uniform, not exponential.  Use
+/// [`UniformInterarrivalTraffic`] in new code.
+#[deprecated(since = "0.1.0", note = "use UniformInterarrivalTraffic instead")]
+pub type PoissonTraffic = UniformInterarrivalTraffic;
+
 // ---------------------------------------------------------------------------
 // AlohaNode state machine
 // ---------------------------------------------------------------------------
@@ -186,9 +212,21 @@ enum Phase {
     Backoff { until: SimTime },
     /// A payload is staged; waiting for `poll_transmit` to collect it.
     ReadyToTransmit,
-    /// `poll_transmit` has been called and the TX is on air; the *next*
-    /// `update` call will compute the absolute backoff deadline from the
-    /// stored relative duration plus the on-air guard time.
+    /// `poll_transmit` has been called and the TX is in flight.
+    ///
+    /// The *next* `update(time)` call will receive `time == tx_start`
+    /// (guaranteed because the Wake event that triggers it was scheduled at
+    /// the same timestamp as the TX).  The absolute backoff deadline is then
+    /// computed as `time + LORA_SF7_DURATION_US + duration_us`, ensuring the
+    /// guard covers the full on-air time even when `duration_us == 0`.
+    ///
+    /// **Invariant:** this phase must be consumed by the very next `update`
+    /// call.  If the scheduler ever delivers a `TxComplete` event before that
+    /// wake (e.g. if on-air duration is zero or event ordering changes), the
+    /// `time` value could be later than tx_start and the backoff deadline
+    /// would be over-estimated.  The current scheduler guarantees this does
+    /// not happen because all three events (two Wakes + the poll_transmit)
+    /// share the same timestamp.
     AwaitingBackoffStart { duration_us: u64 },
 }
 
@@ -213,11 +251,11 @@ enum Phase {
 /// # Example
 ///
 /// ```
-/// use theatron::aloha::{AlohaNode, PoissonTraffic};
+/// use theatron::aloha::{AlohaNode, UniformInterarrivalTraffic};
 /// use theatron::scheduler::NodeHandle;
 /// use theatron::types::NodeId;
 ///
-/// let traffic = PoissonTraffic::new(5_000_000, 1);
+/// let traffic = UniformInterarrivalTraffic::new(5_000_000, 1);
 /// let mut node = AlohaNode::new(NodeId(7), traffic, 500_000, 99);
 /// // Node starts in Idle; update at t=0 schedules first traffic poll.
 /// let next = node.update(0);
@@ -233,11 +271,16 @@ pub struct AlohaNode<T: TrafficModel> {
     /// Staged payload waiting to be collected by `poll_transmit`.
     pending_payload: Option<Vec<u8>>,
     /// How often (µs) to poll the traffic model when idle.
+    ///
+    /// A smaller value increases responsiveness but generates more wake events
+    /// (the default 1 ms produces 1 000 wakes/s per idle node).  Configure
+    /// this via [`AlohaNode::with_poll_interval`] if the default is too coarse
+    /// or too fine for a given simulation.
     poll_interval_us: u64,
 }
 
 impl<T: TrafficModel> AlohaNode<T> {
-    /// Create a new Pure ALOHA node.
+    /// Create a new Pure ALOHA node with the default 1 ms idle poll interval.
     ///
     /// * `id`               — unique node identifier.
     /// * `traffic`          — traffic model producing payloads.
@@ -251,8 +294,32 @@ impl<T: TrafficModel> AlohaNode<T> {
             rng: Xorshift64::new(seed),
             phase: Phase::Idle,
             pending_payload: None,
-            poll_interval_us: 1_000, // 1 ms idle polling granularity
+            poll_interval_us: 1_000, // 1 ms default idle polling granularity
         }
+    }
+
+    /// Override the idle polling interval.
+    ///
+    /// The scheduler wakes an idle node every `interval_us` microseconds to
+    /// check whether the traffic model has a new payload.  A smaller value
+    /// reduces latency between packet arrival and TX at the cost of more
+    /// scheduler events; a larger value is more efficient for long simulations
+    /// with sparse traffic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use theatron::aloha::{AlohaNode, UniformInterarrivalTraffic};
+    /// use theatron::types::NodeId;
+    ///
+    /// let traffic = UniformInterarrivalTraffic::new(10_000_000, 1);
+    /// // Use a 10 ms poll interval to reduce event volume for a long simulation.
+    /// let node = AlohaNode::new(NodeId(1), traffic, 2_000_000, 42)
+    ///     .with_poll_interval(10_000);
+    /// ```
+    pub fn with_poll_interval(mut self, interval_us: u64) -> Self {
+        self.poll_interval_us = interval_us.max(1);
+        self
     }
 
     fn draw_backoff(&mut self) -> u64 {
@@ -266,7 +333,10 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
     }
 
     fn update(&mut self, time: SimTime) -> Option<SimTime> {
-        match self.phase.clone() {
+        // Use mem::replace to move the current phase out without cloning.
+        // This avoids a silent stale-copy hazard if Phase variants ever grow
+        // heap-allocated fields.
+        match mem::replace(&mut self.phase, Phase::Idle) {
             // ── Backoff just started; now we know the current time. ──────────
             //
             // Add the on-air guard (LORA_SF7_DURATION_US) so the node always
@@ -281,6 +351,7 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
             // ── Waiting for backoff to expire. ───────────────────────────────
             Phase::Backoff { until } => {
                 if time < until {
+                    self.phase = Phase::Backoff { until };
                     return Some(until); // still waiting
                 }
                 // Expired — fall through to idle poll below.
@@ -290,6 +361,7 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
             // ── Payload staged; scheduler is about to call poll_transmit. ────
             // Return the same time so poll_transmit is invoked immediately.
             Phase::ReadyToTransmit => {
+                self.phase = Phase::ReadyToTransmit;
                 return Some(time);
             }
 
@@ -307,6 +379,21 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
         }
     }
 
+    /// Check whether the node has a payload ready to transmit.
+    ///
+    /// # Divergence from canonical Pure ALOHA
+    ///
+    /// Classic Pure ALOHA only applies a random backoff on *collision*:
+    /// successfully delivered packets are followed immediately by the next
+    /// traffic-model poll.  This implementation draws a backoff after **every**
+    /// transmission, regardless of outcome, because the `NodeHandle` interface
+    /// does not deliver per-sender collision feedback (the sender is excluded
+    /// from `on_receive` delivery).
+    ///
+    /// The effect is lower peak throughput than the theoretical 1/(2e) ≈ 18.4%
+    /// for canonical Pure ALOHA.  This is acceptable for a reference baseline
+    /// but means the implementation cannot be used directly to validate
+    /// canonical Pure ALOHA throughput curves.
     fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
         if self.phase != Phase::ReadyToTransmit {
             return None;
@@ -389,18 +476,18 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // PoissonTraffic
+    // UniformInterarrivalTraffic
     // ------------------------------------------------------------------
 
     #[test]
     fn poisson_first_call_returns_none() {
-        let mut t = PoissonTraffic::new(1_000_000, 42);
+        let mut t = UniformInterarrivalTraffic::new(1_000_000, 42);
         assert!(t.next_payload(0).is_none());
     }
 
     #[test]
     fn poisson_eventually_fires() {
-        let mut t = PoissonTraffic::new(1_000, 42);
+        let mut t = UniformInterarrivalTraffic::new(1_000, 42);
         // Advance in 1 µs steps; a packet must arrive within 2*mean = 2000 µs.
         let fired = (0u64..2_000).any(|time| t.next_payload(time).is_some());
         assert!(fired, "traffic model must eventually produce a payload");
@@ -408,7 +495,7 @@ mod tests {
 
     #[test]
     fn poisson_second_packet_after_first() {
-        let mut t = PoissonTraffic::new(100, 99);
+        let mut t = UniformInterarrivalTraffic::new(100, 99);
         // Skip until first arrival.
         let first = (0u64..1_000).find(|&time| t.next_payload(time).is_some());
         let first = first.expect("first packet must arrive");
@@ -613,6 +700,47 @@ mod tests {
         assert!(
             node.poll_transmit(0).is_none(),
             "on_receive must not trigger a transmission"
+        );
+    }
+
+    /// A node that is mid-backoff must not alter its TX schedule when it
+    /// receives a frame — Pure ALOHA has no carrier sense or ACK mechanism.
+    #[test]
+    fn on_receive_during_backoff_does_not_alter_schedule() {
+        let traffic = OneShot(Some(vec![0x01]));
+        let mut node = AlohaNode::new(NodeId(9), traffic, 200_000, 5);
+
+        // Drive node to ReadyToTransmit and fire the TX.
+        node.update(0);
+        assert!(node.poll_transmit(0).is_some(), "first TX must fire");
+
+        // update at t=0: enters AwaitingBackoffStart → Backoff with some deadline.
+        let backoff_until = node.update(0).expect("must return backoff deadline");
+        assert!(backoff_until >= LORA_SF7_DURATION_US);
+
+        // Node is now in Backoff.  Deliver a frame mid-backoff.
+        let frame = RxMetadata {
+            payload: vec![0xFF],
+            rssi: -80.0,
+            snr: 10.0,
+            sf: 7,
+            frequency: LORA_FREQUENCY,
+            time: backoff_until / 2,
+        };
+        let wake = node.on_receive(frame, backoff_until / 2);
+        assert!(
+            wake.is_none(),
+            "on_receive during backoff must not request a new wake"
+        );
+
+        // The backoff deadline must be unchanged: update still returns
+        // the original deadline when called before it expires.
+        let mid = backoff_until / 2;
+        let still_waiting = node.update(mid);
+        assert_eq!(
+            still_waiting,
+            Some(backoff_until),
+            "backoff deadline must not be altered by on_receive"
         );
     }
 }

--- a/src/aloha.rs
+++ b/src/aloha.rs
@@ -1,9 +1,26 @@
 //! Pure ALOHA reference MAC protocol.
 //!
-//! Nodes transmit immediately whenever the traffic model produces a payload.
-//! After each transmission (successful or not), a random backoff is drawn from
-//! `U(0, backoff_range_us)` before the next transmission attempt, giving the
-//! channel time to clear and preventing correlated retransmissions.
+//! Nodes transmit immediately whenever the traffic model produces a payload
+//! (no carrier sensing, no time-slotting).  After every transmission a
+//! uniformly-distributed random backoff is drawn before the next traffic-model
+//! poll, preventing perfectly correlated retransmissions.
+//!
+//! # Design notes
+//!
+//! The node is driven entirely through the [`NodeHandle`] interface:
+//!
+//! 1. The scheduler calls `update(time)` on each wake event.
+//! 2. `update` queries the traffic model and, when a payload is available,
+//!    stores it in `pending_payload` and returns `Some(time)` (immediate
+//!    re-wake) so the scheduler calls `poll_transmit` right away.
+//! 3. `poll_transmit` hands the payload to the scheduler and records a
+//!    pending backoff duration.  Because `poll_transmit` does not receive the
+//!    current time, the *absolute* backoff deadline is computed in the next
+//!    `update` call once the post-TX time is known.
+//! 4. On re-wake after the TX completes, `update` sees `pending_backoff_us`,
+//!    computes `until = time + pending_backoff_us`, enters `Backoff { until }`,
+//!    and returns `Some(until)` so the scheduler wakes the node at the right
+//!    moment.
 //!
 //! # Example
 //!
@@ -24,25 +41,37 @@ use crate::time::SimTime;
 use crate::traits::TrafficModel;
 use crate::types::{NodeId, RxMetadata, Transmission};
 
-// LoRa SF7/BW125 time-on-air for a minimal payload (≈56 ms).
+/// LoRa SF7 / BW125 time-on-air for a minimal payload (~56 ms).
 pub const LORA_SF7_DURATION_US: u64 = 56_000;
+/// EU868 primary uplink frequency (Hz).
 pub const LORA_FREQUENCY: u32 = 868_100_000;
+/// Default TX power (dBm).
 pub const LORA_TX_POWER_DBM: i8 = 14;
 
 // ---------------------------------------------------------------------------
-// Minimal self-contained xorshift64 PRNG (no external deps required).
+// Minimal self-contained xorshift64 PRNG — no external crate needed.
 // ---------------------------------------------------------------------------
 
-/// A fast, deterministic pseudo-random number generator based on xorshift64.
+/// A fast, deterministic xorshift64 PRNG.
 ///
-/// Used internally by [`AlohaNode`] and [`PoissonTraffic`] so that the module
-/// has no dependencies beyond `std`.
+/// Used by both [`PoissonTraffic`] and [`AlohaNode`] so the module requires no
+/// dependencies beyond `std`.
+///
+/// # Example
+///
+/// ```
+/// use theatron::aloha::Xorshift64;
+/// let mut rng = Xorshift64::new(42);
+/// let a = rng.next_u64();
+/// let b = rng.next_u64();
+/// assert_ne!(a, b);
+/// ```
 #[derive(Clone)]
 pub struct Xorshift64(u64);
 
 impl Xorshift64 {
-    /// Create a new PRNG seeded with `seed`.  A seed of `0` is replaced by `1`
-    /// to avoid the all-zero fixed point.
+    /// Create a new RNG.  A seed of `0` is replaced by `1` to avoid the
+    /// all-zero fixed point.
     pub fn new(seed: u64) -> Self {
         Self(if seed == 0 { 1 } else { seed })
     }
@@ -59,13 +88,11 @@ impl Xorshift64 {
 
     /// Return a value uniformly distributed in `[0, range)`.
     ///
-    /// Uses rejection sampling to avoid modulo bias; for ranges that are a
-    /// small fraction of `u64::MAX` this is effectively a single draw.
+    /// Uses rejection sampling to eliminate modulo bias.
     pub fn next_u64_below(&mut self, range: u64) -> u64 {
-        if range == 0 {
+        if range <= 1 {
             return 0;
         }
-        // Rejection sampling: discard values in the biased tail.
         let threshold = u64::MAX - (u64::MAX % range);
         loop {
             let v = self.next_u64();
@@ -77,15 +104,14 @@ impl Xorshift64 {
 }
 
 // ---------------------------------------------------------------------------
-// PoissonTraffic — exponentially-distributed inter-arrival times.
+// PoissonTraffic
 // ---------------------------------------------------------------------------
 
-/// A [`TrafficModel`] that generates packet arrivals according to a Poisson
-/// process with a given mean inter-arrival time.
+/// A [`TrafficModel`] that approximates Poisson packet arrivals.
 ///
-/// Each call to [`next_payload`][TrafficModel::next_payload] either returns a
-/// one-byte payload (when the elapsed time since the last arrival exceeds the
-/// next drawn inter-arrival interval) or `None`.
+/// Inter-arrival times are drawn from a uniform distribution centred on
+/// `mean_us` — i.e. `U(mean_us/2, 3·mean_us/2)` — giving the correct mean
+/// while staying entirely in integer arithmetic.
 ///
 /// # Example
 ///
@@ -94,20 +120,21 @@ impl Xorshift64 {
 /// use theatron::traits::TrafficModel;
 ///
 /// let mut traffic = PoissonTraffic::new(1_000_000, 42);
-/// // At time 0 the node hasn't started yet; first call schedules next arrival.
-/// let _ = traffic.next_payload(0);
+/// // First call at time 0 schedules the first arrival; returns None.
+/// assert!(traffic.next_payload(0).is_none());
 /// ```
 pub struct PoissonTraffic {
     mean_us: u64,
     rng: Xorshift64,
+    /// Absolute simulation time at which the next packet arrives.
     next_arrival_us: Option<SimTime>,
 }
 
 impl PoissonTraffic {
-    /// Create a new Poisson traffic model.
+    /// Create a new traffic model.
     ///
     /// * `mean_us` — mean inter-arrival time in microseconds.
-    /// * `seed`    — PRNG seed for reproducibility.
+    /// * `seed`    — RNG seed for reproducibility.
     pub fn new(mean_us: u64, seed: u64) -> Self {
         Self {
             mean_us,
@@ -116,47 +143,12 @@ impl PoissonTraffic {
         }
     }
 
-    /// Draw an exponentially-distributed inter-arrival delay (µs).
-    ///
-    /// Uses the inverse-CDF transform: `delay = -mean * ln(U)` where `U` is
-    /// uniform in `(0, 1]`.  To stay in integer arithmetic we approximate with
-    /// a geometric distribution: `delay = mean * (number of Bernoulli trials
-    /// until first success with p=1/mean)`.  For simplicity we use the
-    /// well-known approximation `delay ≈ -mean * ln(u / 2^64)` evaluated with
-    /// fixed-point: we draw a random `u64` and compute
-    /// `delay = mean * leading_zeros_weight`.
-    ///
-    /// In practice for a simulator this simple geometric approximation is
-    /// sufficient; the distribution is still memoryless.
+    /// Draw the next inter-arrival interval from `U(mean/2, 3·mean/2)`.
     fn draw_interval(&mut self) -> u64 {
-        // Geometric approximation: repeatedly check each bit of a u64 word.
-        // Each bit is independently 0 with probability 1/2, so the number of
-        // leading zeros of a random u64 is geometrically distributed with
-        // p=0.5.  We scale to the desired mean by tossing `mean_us` trials
-        // of a 1-bit coin, which gives a geometric with mean = 2*mean_us.
-        // Instead, we use the standard approximation:
-        //   interval ≈ mean * geometric(p = 1/mean)
-        // implemented as: sum up 1s until the first 0 in a stream of bits
-        // from our RNG, but scaled so that on average we get mean_us.
-        //
-        // Simpler correct approach: use fixed-point log approximation.
-        // We compute: interval = round(-mean * ln(v)) where v = (raw+1)/2^64.
-        // ln approximation via bit-length: ln(v) ≈ -(63 - floor(log2(raw+1))).
-        // This is crude; instead we use a rejection-free geometric:
-        //   Draw bits until we see the first 1; count of 0s = k.
-        //   P(k=n) = (1/2)^(n+1).  Mean k = 1.
-        //   So interval = mean_us * (k+1) gives mean = 2*mean_us — not right.
-        //
-        // Cleanest no-float approach: just use mean_us directly as a fixed
-        // interval with a small random jitter in [0, 2*mean_us).  This gives
-        // uniform inter-arrivals with the correct mean and is reproducible.
-        // For a reference ALOHA implementation the exact distribution shape
-        // matters less than having a nonzero, non-degenerate arrival process.
-        //
-        // Final choice: uniform in [mean_us/2, 3*mean_us/2) → mean = mean_us.
         let half = self.mean_us / 2;
-        let range = self.mean_us; // width of the uniform window
-        half + self.rng.next_u64_below(range.max(1))
+        // range = mean_us so the window spans [half, half + mean_us) = [mean/2, 3·mean/2).
+        let range = self.mean_us.max(1);
+        half + self.rng.next_u64_below(range)
     }
 }
 
@@ -164,13 +156,13 @@ impl TrafficModel for PoissonTraffic {
     fn next_payload(&mut self, time: SimTime) -> Option<Vec<u8>> {
         match self.next_arrival_us {
             None => {
-                // First call: schedule the first arrival relative to now.
+                // First poll: schedule the first arrival relative to now.
                 let interval = self.draw_interval();
                 self.next_arrival_us = Some(time + interval);
                 None
             }
             Some(next) if time >= next => {
-                // Payload ready — schedule the following arrival.
+                // Arrival ready — schedule the next one and return a payload.
                 let interval = self.draw_interval();
                 self.next_arrival_us = Some(time + interval);
                 Some(vec![0x01])
@@ -181,28 +173,41 @@ impl TrafficModel for PoissonTraffic {
 }
 
 // ---------------------------------------------------------------------------
-// AlohaNode
+// AlohaNode state machine
 // ---------------------------------------------------------------------------
 
-/// State machine phases for an ALOHA node.
+/// Internal phase of an [`AlohaNode`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum AlohaPhase {
-    /// Idle: polling traffic model on each wake.
+enum Phase {
+    /// Polling the traffic model on each wake.
     Idle,
-    /// Waiting for ongoing backoff to expire before polling again.
+    /// Waiting until `until` µs before polling again.
     Backoff { until: SimTime },
-    /// A payload is ready; it will be handed to the scheduler on the next
-    /// `poll_transmit` call.
+    /// A payload is staged; waiting for `poll_transmit` to collect it.
     ReadyToTransmit,
+    /// `poll_transmit` has been called and the TX is on air; the *next*
+    /// `update` call will compute the absolute backoff deadline from the
+    /// stored relative duration.
+    AwaitingBackoffStart { duration_us: u64 },
 }
 
-/// A Pure ALOHA node.
+/// A Pure ALOHA node that implements [`NodeHandle`].
 ///
-/// On each wake the node checks its traffic model.  When a payload is
-/// produced the node marks itself `ReadyToTransmit`; the scheduler then
-/// calls `poll_transmit` and the packet goes on air immediately.  After
-/// every transmission a random backoff is inserted before the next
-/// traffic-model poll.
+/// # Transmit flow
+///
+/// ```text
+/// Idle ──(payload ready)──► ReadyToTransmit
+///   ▲                             │
+///   │                     poll_transmit() called
+///   │                             │
+///   │                   AwaitingBackoffStart { duration_us }
+///   │                             │
+///   │                     next update(time) call
+///   │                             │
+///   │                   Backoff { until = time + duration_us }
+///   │                             │
+///   └──────(until reached)────────┘
+/// ```
 ///
 /// # Example
 ///
@@ -212,40 +217,43 @@ enum AlohaPhase {
 /// use theatron::types::NodeId;
 ///
 /// let traffic = PoissonTraffic::new(5_000_000, 1);
-/// let node = AlohaNode::new(NodeId(42), traffic, 500_000, 2);
+/// let mut node = AlohaNode::new(NodeId(7), traffic, 500_000, 99);
+/// // Node starts in Idle; update at t=0 schedules first traffic poll.
+/// let next = node.update(0);
+/// assert!(next.is_some());
 /// ```
 pub struct AlohaNode<T: TrafficModel> {
     id: NodeId,
     traffic: T,
+    /// Upper bound of the uniform backoff window (µs).
     backoff_range_us: u64,
     rng: Xorshift64,
-    phase: AlohaPhase,
+    phase: Phase,
+    /// Staged payload waiting to be collected by `poll_transmit`.
     pending_payload: Option<Vec<u8>>,
-    /// How many µs after waking should `update` request the next wake?
-    next_poll_delay: u64,
+    /// How often (µs) to poll the traffic model when idle.
+    poll_interval_us: u64,
 }
 
 impl<T: TrafficModel> AlohaNode<T> {
-    /// Create a new ALOHA node.
+    /// Create a new Pure ALOHA node.
     ///
     /// * `id`               — unique node identifier.
-    /// * `traffic`          — traffic model that generates payloads.
-    /// * `backoff_range_us` — upper bound of the uniform backoff window (µs).
-    /// * `seed`             — PRNG seed for the backoff RNG.
+    /// * `traffic`          — traffic model producing payloads.
+    /// * `backoff_range_us` — backoff drawn from `U(0, backoff_range_us)`.
+    /// * `seed`             — RNG seed (for the backoff RNG).
     pub fn new(id: NodeId, traffic: T, backoff_range_us: u64, seed: u64) -> Self {
         Self {
             id,
             traffic,
             backoff_range_us,
             rng: Xorshift64::new(seed),
-            phase: AlohaPhase::Idle,
+            phase: Phase::Idle,
             pending_payload: None,
-            // Poll the traffic model every 1 ms when idle.
-            next_poll_delay: 1_000,
+            poll_interval_us: 1_000, // 1 ms idle polling granularity
         }
     }
 
-    /// Draw a random backoff duration in `[0, backoff_range_us)`.
     fn draw_backoff(&mut self) -> u64 {
         self.rng.next_u64_below(self.backoff_range_us.max(1))
     }
@@ -256,65 +264,55 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
         self.id
     }
 
-    /// Called by the scheduler when this node wakes up.
-    ///
-    /// Returns the next wake time or `None` if the node has nothing pending.
     fn update(&mut self, time: SimTime) -> Option<SimTime> {
-        match &self.phase.clone() {
-            AlohaPhase::Backoff { until } => {
-                if time >= *until {
-                    // Backoff expired — go back to idle polling.
-                    self.phase = AlohaPhase::Idle;
-                    // Fall through to idle handling below.
-                } else {
-                    // Still in backoff; wake again when it expires.
-                    return Some(*until);
+        match self.phase.clone() {
+            // ── Backoff just started; now we know the current time. ──────────
+            Phase::AwaitingBackoffStart { duration_us } => {
+                let until = time + duration_us;
+                self.phase = Phase::Backoff { until };
+                return Some(until);
+            }
+
+            // ── Waiting for backoff to expire. ───────────────────────────────
+            Phase::Backoff { until } => {
+                if time < until {
+                    return Some(until); // still waiting
                 }
+                // Expired — fall through to idle poll below.
+                self.phase = Phase::Idle;
             }
-            AlohaPhase::ReadyToTransmit => {
-                // poll_transmit will pick up the payload; stay in this phase
-                // until poll_transmit clears it.  Return soon so the scheduler
-                // can call poll_transmit.
-                return Some(time + 1);
+
+            // ── Payload staged; scheduler is about to call poll_transmit. ────
+            // Return the same time so poll_transmit is invoked immediately.
+            Phase::ReadyToTransmit => {
+                return Some(time);
             }
-            AlohaPhase::Idle => {}
+
+            Phase::Idle => {}
         }
 
-        // Idle: ask the traffic model for a payload.
-        let payload = self.traffic.next_payload(time);
-        if let Some(p) = payload {
-            self.pending_payload = Some(p);
-            self.phase = AlohaPhase::ReadyToTransmit;
-            // Wake immediately so poll_transmit is called right away.
-            Some(time)
-        } else {
-            // Nothing yet — poll again after next_poll_delay.
-            Some(time + self.next_poll_delay)
+        // Idle: ask the traffic model for the next payload.
+        match self.traffic.next_payload(time) {
+            Some(payload) => {
+                self.pending_payload = Some(payload);
+                self.phase = Phase::ReadyToTransmit;
+                Some(time) // re-wake immediately so poll_transmit is called
+            }
+            None => Some(time + self.poll_interval_us),
         }
     }
 
-    /// Called by the scheduler immediately after `update` returns.
-    ///
-    /// If a payload is ready, returns a `Transmission` and enters backoff.
     fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
-        if self.phase != AlohaPhase::ReadyToTransmit {
+        if self.phase != Phase::ReadyToTransmit {
             return None;
         }
         let payload = self.pending_payload.take()?;
-        // Transition: after transmitting, always back off.
         let backoff = self.draw_backoff();
-        // We don't know the exact current time in poll_transmit, but the
-        // scheduler will call update next with the post-TX time; we store a
-        // relative backoff that will be applied in the next update call.
-        // To pass the backoff duration to update we temporarily encode it
-        // in the Backoff phase with a sentinel: `until = backoff` (relative).
-        // update() will detect that until < time and treat it as expired,
-        // so we add a large offset.  Better: store a pending_backoff field.
-        // We use a dedicated field for clarity.
-        self.phase = AlohaPhase::Backoff {
-            until: u64::MAX, // placeholder; fixed up in on_receive or next update
+        // We don't have the current time here; record the relative duration
+        // so `update` can compute the absolute deadline on its next call.
+        self.phase = Phase::AwaitingBackoffStart {
+            duration_us: backoff,
         };
-        self.pending_backoff_duration = backoff;
         Some(Transmission {
             payload,
             sf: 7,
@@ -326,11 +324,197 @@ impl<T: TrafficModel> NodeHandle for AlohaNode<T> {
         })
     }
 
-    /// Called when a frame is received from another node.
-    ///
-    /// Pure ALOHA has no carrier sense, so received frames do not affect
-    /// the transmit schedule.
+    /// Pure ALOHA has no carrier sense; received frames do not affect the TX
+    /// schedule.
     fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
         None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Xorshift64
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn xorshift_zero_seed_becomes_one() {
+        let mut a = Xorshift64::new(0);
+        let mut b = Xorshift64::new(1);
+        assert_eq!(a.next_u64(), b.next_u64());
+    }
+
+    #[test]
+    fn xorshift_deterministic() {
+        let mut a = Xorshift64::new(42);
+        let mut b = Xorshift64::new(42);
+        for _ in 0..200 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn xorshift_nonzero_output() {
+        let mut rng = Xorshift64::new(1);
+        for _ in 0..1_000 {
+            assert_ne!(rng.next_u64(), 0);
+        }
+    }
+
+    #[test]
+    fn xorshift_below_range_in_bounds() {
+        let mut rng = Xorshift64::new(7);
+        let range = 100u64;
+        for _ in 0..10_000 {
+            assert!(rng.next_u64_below(range) < range);
+        }
+    }
+
+    #[test]
+    fn xorshift_below_zero_range_returns_zero() {
+        let mut rng = Xorshift64::new(3);
+        assert_eq!(rng.next_u64_below(0), 0);
+        assert_eq!(rng.next_u64_below(1), 0);
+    }
+
+    // ------------------------------------------------------------------
+    // PoissonTraffic
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn poisson_first_call_returns_none() {
+        let mut t = PoissonTraffic::new(1_000_000, 42);
+        assert!(t.next_payload(0).is_none());
+    }
+
+    #[test]
+    fn poisson_eventually_fires() {
+        let mut t = PoissonTraffic::new(1_000, 42);
+        // Advance in 1 µs steps; a packet must arrive within 2*mean = 2000 µs.
+        let fired = (0u64..2_000).any(|time| t.next_payload(time).is_some());
+        assert!(fired, "traffic model must eventually produce a payload");
+    }
+
+    #[test]
+    fn poisson_second_packet_after_first() {
+        let mut t = PoissonTraffic::new(100, 99);
+        // Skip until first arrival.
+        let first = (0u64..1_000).find(|&time| t.next_payload(time).is_some());
+        let first = first.expect("first packet must arrive");
+        // Second packet must arrive later.
+        let second = (first + 1..first + 1_000).find(|&time| t.next_payload(time).is_some());
+        assert!(second.is_some(), "second packet must arrive after first");
+        assert!(second.unwrap() > first);
+    }
+
+    // ------------------------------------------------------------------
+    // AlohaNode
+    // ------------------------------------------------------------------
+
+    struct OneShot(Option<Vec<u8>>);
+    impl TrafficModel for OneShot {
+        fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
+            self.0.take()
+        }
+    }
+
+    struct NeverFire;
+    impl TrafficModel for NeverFire {
+        fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    #[test]
+    fn idle_node_keeps_waking() {
+        let mut node = AlohaNode::new(NodeId(1), NeverFire, 100_000, 1);
+        let w1 = node.update(0);
+        assert!(w1.is_some());
+        let t1 = w1.unwrap();
+        assert!(t1 > 0, "should schedule a future wake");
+        let w2 = node.update(t1);
+        assert!(w2.is_some());
+    }
+
+    #[test]
+    fn one_shot_produces_transmission() {
+        let traffic = OneShot(Some(vec![0xAB]));
+        let mut node = AlohaNode::new(NodeId(2), traffic, 100_000, 7);
+        // Cycle until ReadyToTransmit.
+        let mut time = 0u64;
+        let tx = loop {
+            let next = node.update(time);
+            let t = node.poll_transmit(time);
+            if t.is_some() {
+                break t;
+            }
+            time = next.unwrap_or(time + 1_000);
+        };
+        assert!(tx.is_some());
+        let tx = tx.unwrap();
+        assert_eq!(tx.payload, vec![0xAB]);
+        assert_eq!(tx.sf, 7);
+        assert_eq!(tx.frequency, LORA_FREQUENCY);
+        assert_eq!(tx.duration_us, LORA_SF7_DURATION_US);
+    }
+
+    #[test]
+    fn poll_transmit_clears_payload() {
+        let traffic = OneShot(Some(vec![0x01]));
+        let mut node = AlohaNode::new(NodeId(3), traffic, 0, 5);
+        let mut time = 0u64;
+        let mut tx_count = 0;
+        for _ in 0..200 {
+            let next = node.update(time);
+            if node.poll_transmit(time).is_some() {
+                tx_count += 1;
+            }
+            time = next.unwrap_or(time + 1_000);
+        }
+        assert_eq!(tx_count, 1, "one-shot traffic should cause exactly one TX");
+    }
+
+    #[test]
+    fn backoff_delays_next_tx() {
+        // Two one-shots with a 500 ms backoff window.
+        struct TwoShot(u8);
+        impl TrafficModel for TwoShot {
+            fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
+                if self.0 > 0 {
+                    self.0 -= 1;
+                    Some(vec![self.0])
+                } else {
+                    None
+                }
+            }
+        }
+
+        let backoff_range = 500_000u64;
+        let mut node = AlohaNode::new(NodeId(4), TwoShot(2), backoff_range, 11);
+        let mut tx_times = Vec::new();
+        let mut time = 0u64;
+        for _ in 0..2_000_000 {
+            let next = node.update(time);
+            if node.poll_transmit(time).is_some() {
+                tx_times.push(time);
+            }
+            if tx_times.len() == 2 {
+                break;
+            }
+            time = next.unwrap_or(time + 1_000);
+        }
+        assert_eq!(tx_times.len(), 2, "should see exactly 2 transmissions");
+        // After the first TX the node enters backoff, so the second TX must be
+        // at least the TX duration later (backoff ≥ 0 but TX itself takes time).
+        assert!(
+            tx_times[1] > tx_times[0],
+            "second TX must come after first TX"
+        );
     }
 }

--- a/src/aloha.rs
+++ b/src/aloha.rs
@@ -669,8 +669,11 @@ mod tests {
         let until = node.update(0).expect("must return the backoff deadline");
         assert!(until >= LORA_SF7_DURATION_US, "deadline must be after on-air time");
 
-        // Call update with time strictly before the deadline.
+        // Use a mid-point strictly before the deadline.  The explicit assert
+        // documents the precondition required for the still-waiting branch to
+        // fire, making it obvious if the arithmetic ever changes.
         let mid = until / 2;
+        assert!(mid < until, "mid must be strictly before deadline for this test to be meaningful");
         let again = node.update(mid);
         assert_eq!(
             again,
@@ -679,10 +682,11 @@ mod tests {
         );
     }
 
-    /// `on_receive` is a no-op for Pure ALOHA; it must return `None` and not
-    /// mutate the node state.
+    /// `on_receive` is a no-op for Pure ALOHA: it returns `None` (no
+    /// scheduler wake requested) and leaves the node state unchanged.
+    /// Both properties are asserted here.
     #[test]
-    fn on_receive_returns_none() {
+    fn on_receive_is_noop() {
         let mut node = AlohaNode::new(NodeId(8), NeverFire, 0, 1);
         let frame = RxMetadata {
             payload: vec![0xDE, 0xAD],
@@ -692,11 +696,12 @@ mod tests {
             frequency: LORA_FREQUENCY,
             time: 0,
         };
+        // Return value: must not request a wake.
         assert!(
             node.on_receive(frame, 0).is_none(),
             "Pure ALOHA on_receive must always return None"
         );
-        // Node must still be idle after the receive event.
+        // State invariance: node must remain idle, not ready to transmit.
         assert!(
             node.poll_transmit(0).is_none(),
             "on_receive must not trigger a transmission"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -3,6 +3,82 @@ use crate::types::{ChannelEvent, NodeId, RxMetadata, Transmission};
 
 pub type CompletedTx = (NodeId, bool, bool, RxMetadata);
 
+/// Default LoRa path loss in dB (free-space + typical indoor attenuation baseline).
+pub const LORA_PATH_LOSS_DB: f32 = 100.0;
+
+/// Default LoRa noise floor in dBm (LoRa sensitivity at SF7/125 kHz).
+pub const LORA_NOISE_FLOOR_DBM: f32 = -117.0;
+
+/// Default co-channel rejection threshold in dB (LoRa capture effect threshold).
+pub const LORA_CO_CHANNEL_REJECTION_DB: f32 = 6.0;
+
+/// Configuration for physical-layer channel parameters.
+///
+/// Construct with [`ChannelConfig::lora_defaults()`] for LoRa or supply
+/// custom values for other protocols.
+///
+/// # Examples
+///
+/// ```
+/// use theatron::channel::ChannelConfig;
+///
+/// // LoRa defaults
+/// let cfg = ChannelConfig::lora_defaults();
+///
+/// // Custom 802.15.4 / Zigbee-like parameters
+/// let cfg = ChannelConfig {
+///     path_loss_db: 80.0,
+///     noise_floor_dbm: -100.0,
+///     co_channel_rejection_db: 3.0,
+/// };
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChannelConfig {
+    /// Path loss applied to every transmission (dB). Higher values mean
+    /// the received signal is weaker.
+    pub path_loss_db: f32,
+
+    /// Noise floor of the receiver (dBm). Used to compute SNR.
+    pub noise_floor_dbm: f32,
+
+    /// Minimum power difference (dB) required for the stronger signal to
+    /// survive a co-channel collision via the capture effect.
+    pub co_channel_rejection_db: f32,
+}
+
+impl ChannelConfig {
+    /// Return the LoRa default parameters used by [`Channel::new()`].
+    ///
+    /// | Parameter               | Value    |
+    /// |-------------------------|----------|
+    /// | `path_loss_db`          | 100 dB   |
+    /// | `noise_floor_dbm`       | -117 dBm |
+    /// | `co_channel_rejection_db` | 6 dB   |
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::channel::ChannelConfig;
+    /// let cfg = ChannelConfig::lora_defaults();
+    /// assert_eq!(cfg.path_loss_db, 100.0);
+    /// assert_eq!(cfg.noise_floor_dbm, -117.0);
+    /// assert_eq!(cfg.co_channel_rejection_db, 6.0);
+    /// ```
+    pub fn lora_defaults() -> Self {
+        Self {
+            path_loss_db: LORA_PATH_LOSS_DB,
+            noise_floor_dbm: LORA_NOISE_FLOOR_DBM,
+            co_channel_rejection_db: LORA_CO_CHANNEL_REJECTION_DB,
+        }
+    }
+}
+
+impl Default for ChannelConfig {
+    fn default() -> Self {
+        Self::lora_defaults()
+    }
+}
+
 struct ActiveTransmission {
     sender: NodeId,
     payload: Vec<u8>,
@@ -18,16 +94,18 @@ struct ActiveTransmission {
 }
 
 /// A simulated wireless channel with collision detection.
+///
+/// Physical-layer parameters are controlled by [`ChannelConfig`]. Use
+/// [`Channel::new()`] for LoRa defaults or [`Channel::with_config()`] to
+/// supply custom parameters for other protocols.
 pub struct Channel {
     active: Vec<ActiveTransmission>,
     completed: Vec<ActiveTransmission>,
-    co_channel_rejection_db: f32,
-    path_loss_db: f32,
-    noise_floor_dbm: f32,
+    config: ChannelConfig,
 }
 
 impl Channel {
-    /// Create a new empty channel.
+    /// Create a new empty channel using LoRa default parameters.
     ///
     /// # Examples
     ///
@@ -36,28 +114,70 @@ impl Channel {
     /// let ch = Channel::new();
     /// ```
     pub fn new() -> Self {
+        Self::with_config(ChannelConfig::lora_defaults())
+    }
+
+    /// Create a new channel with the given [`ChannelConfig`].
+    ///
+    /// This is the primary entry point for non-LoRa protocols.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::channel::{Channel, ChannelConfig};
+    ///
+    /// // Simulate a short-range, low-noise environment (e.g. 802.15.4)
+    /// let ch = Channel::with_config(ChannelConfig {
+    ///     path_loss_db: 80.0,
+    ///     noise_floor_dbm: -100.0,
+    ///     co_channel_rejection_db: 3.0,
+    /// });
+    /// ```
+    pub fn with_config(config: ChannelConfig) -> Self {
         Self {
             active: Vec::new(),
             completed: Vec::new(),
-            co_channel_rejection_db: 6.0,
-            path_loss_db: 100.0,
-            noise_floor_dbm: -117.0,
+            config,
         }
     }
 
+    /// Create a new channel overriding only the co-channel rejection threshold.
+    ///
+    /// All other parameters default to LoRa values. Prefer
+    /// [`Channel::with_config()`] when you want to control multiple parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::channel::Channel;
+    /// let ch = Channel::with_co_channel_rejection(10.0);
+    /// ```
     pub fn with_co_channel_rejection(db: f32) -> Self {
-        Self {
+        Self::with_config(ChannelConfig {
             co_channel_rejection_db: db,
-            ..Self::new()
-        }
+            ..ChannelConfig::lora_defaults()
+        })
+    }
+
+    /// Return a reference to the channel's physical-layer configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::channel::{Channel, ChannelConfig};
+    /// let ch = Channel::new();
+    /// assert_eq!(ch.config().path_loss_db, 100.0);
+    /// ```
+    pub fn config(&self) -> &ChannelConfig {
+        &self.config
     }
 
     pub fn compute_rssi(&self, tx_power_dbm: i8) -> f32 {
-        tx_power_dbm as f32 - self.path_loss_db
+        tx_power_dbm as f32 - self.config.path_loss_db
     }
 
     pub fn compute_snr(&self, rssi: f32) -> f32 {
-        rssi - self.noise_floor_dbm
+        rssi - self.config.noise_floor_dbm
     }
 
     /// Begin a transmission on the channel, returning a `TransmissionStarted` event.
@@ -98,10 +218,10 @@ impl Channel {
                 && active.sf == tx.sf
             {
                 let delta = tx.tx_power_dbm as f32 - active.tx_power_dbm as f32;
-                if delta >= self.co_channel_rejection_db {
+                if delta >= self.config.co_channel_rejection_db {
                     active.collided = true;
                     new_captured = true;
-                } else if delta <= -self.co_channel_rejection_db {
+                } else if delta <= -self.config.co_channel_rejection_db {
                     new_collided = true;
                     active.captured = true;
                 } else {
@@ -173,45 +293,6 @@ impl Channel {
         events
     }
 
-    /// Return all completed, non-collided transmissions as received frames.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::channel::Channel;
-    /// use theatron::types::{NodeId, Transmission};
-    ///
-    /// let mut ch = Channel::new();
-    /// let tx = Transmission {
-    ///     payload: vec![0x42],
-    ///     sf: 7,
-    ///     bandwidth: 125_000,
-    ///     coding_rate: 5,
-    ///     frequency: 868_100_000,
-    ///     duration_us: 50_000,
-    ///     tx_power_dbm: 14,
-    /// };
-    /// ch.begin_transmission(NodeId(1), &tx, 0);
-    /// ch.resolve_at(50_000);
-    /// let received = ch.deliver_to(50_000);
-    /// assert_eq!(received.len(), 1);
-    /// assert_eq!(received[0].payload, vec![0x42]);
-    /// ```
-    pub fn deliver_to(&self, time: SimTime) -> Vec<RxMetadata> {
-        self.completed
-            .iter()
-            .filter(|tx| tx.end <= time && !tx.collided)
-            .map(|tx| RxMetadata {
-                payload: tx.payload.clone(),
-                rssi: self.compute_rssi(tx.tx_power_dbm),
-                snr: self.compute_snr(self.compute_rssi(tx.tx_power_dbm)),
-                sf: tx.sf,
-                frequency: tx.frequency,
-                time: tx.end,
-            })
-            .collect()
-    }
-
     /// Drain and return all completed transmissions as `CompletedTx` tuples.
     ///
     /// Each entry is `(sender, collided, captured, RxMetadata)`. RSSI and SNR
@@ -241,8 +322,8 @@ impl Channel {
     /// assert!(!completed[0].1);
     /// ```
     pub fn drain_completed(&mut self) -> Vec<CompletedTx> {
-        let path_loss_db = self.path_loss_db;
-        let noise_floor_dbm = self.noise_floor_dbm;
+        let path_loss_db = self.config.path_loss_db;
+        let noise_floor_dbm = self.config.noise_floor_dbm;
         self.completed
             .drain(..)
             .map(|tx| {
@@ -304,14 +385,15 @@ mod tests {
     }
 
     #[test]
-    fn single_transmission_delivers() {
+    fn single_transmission_completes_without_collision() {
         let mut ch = Channel::new();
         let tx = make_tx(7, 868_100_000, 50_000);
         ch.begin_transmission(NodeId(1), &tx, 0);
         ch.resolve_at(50_000);
-        let delivered = ch.deliver_to(50_000);
-        assert_eq!(delivered.len(), 1);
-        assert_eq!(delivered[0].payload, vec![0x01, 0x02]);
+        let completed = ch.drain_completed();
+        assert_eq!(completed.len(), 1);
+        assert!(!completed[0].1, "single TX should not collide");
+        assert_eq!(completed[0].3.payload, vec![0x01, 0x02]);
     }
 
     #[test]
@@ -322,8 +404,8 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
-        assert_eq!(delivered.len(), 0);
+        let completed = ch.drain_completed();
+        assert!(completed.iter().all(|(_, collided, _, _)| *collided));
     }
 
     #[test]
@@ -334,8 +416,9 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
-        assert_eq!(delivered.len(), 2);
+        let completed = ch.drain_completed();
+        assert_eq!(completed.len(), 2);
+        assert!(completed.iter().all(|(_, collided, _, _)| !collided));
     }
 
     #[test]
@@ -346,8 +429,9 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
-        assert_eq!(delivered.len(), 2);
+        let completed = ch.drain_completed();
+        assert_eq!(completed.len(), 2);
+        assert!(completed.iter().all(|(_, collided, _, _)| !collided));
     }
 
     #[test]
@@ -360,8 +444,9 @@ mod tests {
         ch.drain_completed();
         ch.begin_transmission(NodeId(2), &tx2, 60_000);
         ch.resolve_at(110_000);
-        let delivered = ch.deliver_to(110_000);
-        assert_eq!(delivered.len(), 1);
+        let completed = ch.drain_completed();
+        assert_eq!(completed.len(), 1);
+        assert!(!completed[0].1);
     }
 
     #[test]
@@ -399,9 +484,13 @@ mod tests {
         ch.begin_transmission(NodeId(1), &strong, 0);
         ch.begin_transmission(NodeId(2), &weak, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
-        assert_eq!(delivered.len(), 1);
-        assert_eq!(delivered[0].payload, vec![0x01, 0x02]);
+        let completed = ch.drain_completed();
+        let strong_entry = completed
+            .iter()
+            .find(|(id, _, _, _)| *id == NodeId(1))
+            .unwrap();
+        assert!(!strong_entry.1, "strong should not be collided");
+        assert!(strong_entry.2, "strong should be captured");
     }
 
     #[test]
@@ -413,16 +502,10 @@ mod tests {
         ch.begin_transmission(NodeId(2), &weak, 10_000);
         ch.resolve_at(60_000);
         let completed = ch.drain_completed();
-        let strong_entry = completed
-            .iter()
-            .find(|(id, _, _, _)| *id == NodeId(1))
-            .unwrap();
         let weak_entry = completed
             .iter()
             .find(|(id, _, _, _)| *id == NodeId(2))
             .unwrap();
-        assert!(!strong_entry.1, "strong should not be collided");
-        assert!(strong_entry.2, "strong should be captured");
         assert!(weak_entry.1, "weak should be collided");
     }
 
@@ -434,8 +517,11 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
-        assert_eq!(delivered.len(), 0, "delta=5 < threshold=6 → both collide");
+        let completed = ch.drain_completed();
+        assert!(
+            completed.iter().all(|(_, collided, _, _)| *collided),
+            "delta=5 < threshold=6 -> both collide"
+        );
     }
 
     #[test]
@@ -446,11 +532,12 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
+        let completed = ch.drain_completed();
+        let non_collided: Vec<_> = completed.iter().filter(|(_, c, _, _)| !c).collect();
         assert_eq!(
-            delivered.len(),
+            non_collided.len(),
             1,
-            "delta=6 == threshold=6 → stronger survives"
+            "delta=6 == threshold=6 -> stronger survives"
         );
     }
 
@@ -464,13 +551,13 @@ mod tests {
         ch.begin_transmission(NodeId(2), &medium, 5_000);
         ch.begin_transmission(NodeId(3), &weak, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
+        let completed = ch.drain_completed();
+        let non_collided: Vec<_> = completed.iter().filter(|(_, c, _, _)| !c).collect();
         assert_eq!(
-            delivered.len(),
+            non_collided.len(),
             1,
             "only strongest survives three-way collision"
         );
-        let completed = ch.drain_completed();
         let strong_entry = completed
             .iter()
             .find(|(id, _, _, _)| *id == NodeId(1))
@@ -486,8 +573,11 @@ mod tests {
         ch.begin_transmission(NodeId(1), &tx1, 0);
         ch.begin_transmission(NodeId(2), &tx2, 10_000);
         ch.resolve_at(60_000);
-        let delivered = ch.deliver_to(60_000);
-        assert_eq!(delivered.len(), 0, "delta=6 < threshold=10 → both collide");
+        let completed = ch.drain_completed();
+        assert!(
+            completed.iter().all(|(_, collided, _, _)| *collided),
+            "delta=6 < threshold=10 -> both collide"
+        );
     }
 
     #[test]
@@ -496,10 +586,143 @@ mod tests {
         let tx = make_tx_power(7, 868_100_000, 50_000, 14);
         ch.begin_transmission(NodeId(1), &tx, 0);
         ch.resolve_at(50_000);
-        let delivered = ch.deliver_to(50_000);
-        assert_eq!(delivered.len(), 1);
-        assert!((delivered[0].rssi - (14.0_f32 - 100.0)).abs() < 0.001);
-        assert!((delivered[0].snr - (-86.0_f32 - (-117.0))).abs() < 0.001);
+        let completed = ch.drain_completed();
+        assert_eq!(completed.len(), 1);
+        let meta = &completed[0].3;
+        assert!((meta.rssi - (14.0_f32 - 100.0)).abs() < 0.001);
+        assert!((meta.snr - (-86.0_f32 - (-117.0))).abs() < 0.001);
+    }
+
+    // --- ChannelConfig tests ---
+
+    #[test]
+    fn channel_config_lora_defaults_matches_constants() {
+        let cfg = ChannelConfig::lora_defaults();
+        assert_eq!(cfg.path_loss_db, LORA_PATH_LOSS_DB);
+        assert_eq!(cfg.noise_floor_dbm, LORA_NOISE_FLOOR_DBM);
+        assert_eq!(cfg.co_channel_rejection_db, LORA_CO_CHANNEL_REJECTION_DB);
+    }
+
+    #[test]
+    fn channel_config_default_is_lora_defaults() {
+        assert_eq!(ChannelConfig::default(), ChannelConfig::lora_defaults());
+    }
+
+    #[test]
+    fn with_config_exposes_config_accessor() {
+        let cfg = ChannelConfig {
+            path_loss_db: 70.0,
+            noise_floor_dbm: -95.0,
+            co_channel_rejection_db: 3.0,
+        };
+        let ch = Channel::with_config(cfg.clone());
+        assert_eq!(*ch.config(), cfg);
+    }
+
+    /// A channel with lower path loss (shorter range / indoor) produces a higher
+    /// RSSI for the same transmit power.
+    #[test]
+    fn low_path_loss_config_produces_higher_rssi() {
+        let low_loss_cfg = ChannelConfig {
+            path_loss_db: 60.0,
+            noise_floor_dbm: -100.0,
+            co_channel_rejection_db: 3.0,
+        };
+        let mut ch_lora = Channel::new(); // path_loss = 100 dB
+        let mut ch_short_range = Channel::with_config(low_loss_cfg);
+
+        let tx = make_tx_power(7, 868_100_000, 50_000, 14);
+
+        for ch in [&mut ch_lora, &mut ch_short_range] {
+            ch.begin_transmission(NodeId(1), &tx, 0);
+            ch.resolve_at(50_000);
+        }
+
+        let lora_rx = ch_lora.drain_completed();
+        let short_rx = ch_short_range.drain_completed();
+
+        assert_eq!(lora_rx.len(), 1);
+        assert_eq!(short_rx.len(), 1);
+        assert!(
+            short_rx[0].3.rssi > lora_rx[0].3.rssi,
+            "lower path loss must yield higher RSSI: short_range={} lora={}",
+            short_rx[0].3.rssi,
+            lora_rx[0].3.rssi,
+        );
+    }
+
+    /// A channel with a lower noise floor produces a higher SNR for the same signal.
+    #[test]
+    fn lower_noise_floor_produces_higher_snr() {
+        let quiet_cfg = ChannelConfig {
+            path_loss_db: 100.0,
+            noise_floor_dbm: -130.0, // quieter than LoRa default of -117 dBm
+            co_channel_rejection_db: 6.0,
+        };
+        let mut ch_lora = Channel::new();
+        let mut ch_quiet = Channel::with_config(quiet_cfg);
+
+        let tx = make_tx_power(7, 868_100_000, 50_000, 14);
+
+        for ch in [&mut ch_lora, &mut ch_quiet] {
+            ch.begin_transmission(NodeId(1), &tx, 0);
+            ch.resolve_at(50_000);
+        }
+
+        let lora_rx = ch_lora.drain_completed();
+        let quiet_rx = ch_quiet.drain_completed();
+
+        assert_eq!(lora_rx.len(), 1);
+        assert_eq!(quiet_rx.len(), 1);
+        assert!(
+            quiet_rx[0].3.snr > lora_rx[0].3.snr,
+            "lower noise floor must yield higher SNR: quiet={} lora={}",
+            quiet_rx[0].3.snr,
+            lora_rx[0].3.snr,
+        );
+    }
+
+    /// A channel with a higher capture threshold behaves more conservatively:
+    /// a power delta that would survive capture on the LoRa channel causes both
+    /// signals to collide instead.
+    #[test]
+    fn high_capture_threshold_prevents_capture_where_lora_would_survive() {
+        // delta = 6 dB exactly meets the LoRa threshold → strong survives on LoRa
+        let mut ch_lora = Channel::new(); // threshold = 6 dB
+        let mut ch_strict = Channel::with_config(ChannelConfig {
+            path_loss_db: 100.0,
+            noise_floor_dbm: -117.0,
+            co_channel_rejection_db: 10.0, // stricter: 6 dB delta not enough
+        });
+
+        let strong = make_tx_power(7, 868_100_000, 50_000, 20);
+        let weak = make_tx_power(7, 868_100_000, 50_000, 14);
+
+        for ch in [&mut ch_lora, &mut ch_strict] {
+            ch.begin_transmission(NodeId(1), &strong, 0);
+            ch.begin_transmission(NodeId(2), &weak, 10_000);
+            ch.resolve_at(60_000);
+        }
+
+        let lora_rx = ch_lora.drain_completed();
+        let strict_rx = ch_strict.drain_completed();
+
+        assert_eq!(
+            lora_rx
+                .iter()
+                .filter(|(_, collided, _, _)| !collided)
+                .count(),
+            1,
+            "LoRa threshold=6: strong signal must survive"
+        );
+        assert_eq!(
+            strict_rx
+                .iter()
+                .filter(|(_, collided, _, _)| !collided)
+                .count(),
+            0,
+            "strict threshold=10: both collide at delta=6"
+        );
     }
 
     proptest! {
@@ -551,5 +774,79 @@ mod tests {
             let completed = ch.drain_completed();
             prop_assert!(completed.iter().all(|(_, collided, _, _)| !collided));
         }
+    }
+
+    #[test]
+    fn test_no_active_after_resolve() {
+        let mut ch = Channel::new();
+        let tx1 = make_tx(7, 868_100_000, 50_000);
+        let tx2 = make_tx(7, 868_300_000, 30_000);
+        let tx3 = make_tx(8, 868_100_000, 80_000);
+        ch.begin_transmission(NodeId(1), &tx1, 0);
+        ch.begin_transmission(NodeId(2), &tx2, 10_000);
+        ch.begin_transmission(NodeId(3), &tx3, 20_000);
+
+        let resolve_time = 50_000;
+        ch.resolve_at(resolve_time);
+
+        // tx1 (end=50k) and tx2 (end=40k) resolved; tx3 (end=100k) still active.
+        let events = ch.resolve_at(100_000);
+        assert_eq!(
+            events.len(),
+            1,
+            "only the transmission ending at 100k should remain active"
+        );
+
+        // After full resolution, no active transmissions should remain.
+        let events_empty = ch.resolve_at(200_000);
+        assert_eq!(
+            events_empty.len(),
+            0,
+            "no transmissions should remain active after resolving past all end times"
+        );
+    }
+
+    #[test]
+    fn test_collision_state_consistency() {
+        let mut ch = Channel::new();
+        let tx1 = make_tx(7, 868_100_000, 50_000);
+        let tx2 = make_tx(7, 868_100_000, 50_000);
+        ch.begin_transmission(NodeId(1), &tx1, 0);
+        ch.begin_transmission(NodeId(2), &tx2, 10_000);
+
+        ch.resolve_at(60_000);
+        let completed = ch.drain_completed();
+        assert_eq!(completed.len(), 2);
+
+        for (sender, collided, captured, _meta) in &completed {
+            assert!(
+                *collided,
+                "sender {:?} should be collided for equal-power overlap",
+                sender
+            );
+            assert!(
+                !*captured,
+                "sender {:?} should not be captured for equal-power overlap",
+                sender
+            );
+        }
+
+        // Verify collided frames are not delivered.
+        let mut ch2 = Channel::new();
+        let tx_a = make_tx(7, 868_100_000, 50_000);
+        let tx_b = make_tx(7, 868_100_000, 50_000);
+        ch2.begin_transmission(NodeId(10), &tx_a, 0);
+        ch2.begin_transmission(NodeId(11), &tx_b, 5_000);
+        ch2.resolve_at(55_000);
+        let delivered: Vec<_> = ch2
+            .drain_completed()
+            .into_iter()
+            .filter(|(_, collided, _, _)| !*collided)
+            .collect();
+        assert_eq!(
+            delivered.len(),
+            0,
+            "equal-power collisions should not be delivered"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aloha;
 pub mod channel;
 pub mod metrics;
 pub mod scheduler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod aloha;
 pub mod channel;
 pub mod metrics;
+#[cfg(feature = "prng")]
+pub mod prng;
 pub mod scheduler;
 pub mod time;
 pub mod traits;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,6 +73,17 @@ impl MetricsCollector {
         self.total_collisions += 1;
     }
 
+    /// Record a capture event (a frame successfully decoded despite a simultaneous
+    /// transmission on the same channel, via the radio capture effect).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::metrics::MetricsCollector;
+    /// let mut m = MetricsCollector::new();
+    /// m.record_capture();
+    /// assert_eq!(m.total_captures, 1);
+    /// ```
     pub fn record_capture(&mut self) {
         self.total_captures += 1;
     }

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -1,0 +1,135 @@
+//! A minimal, deterministic PRNG for reproducible simulations.
+//!
+//! # Examples
+//!
+//! ```
+//! use theatron::prng::Xorshift64;
+//! use rand_core::RngCore;
+//!
+//! let mut rng = Xorshift64::new(42);
+//! let a = rng.next_u64();
+//! let mut rng2 = Xorshift64::new(42);
+//! assert_eq!(a, rng2.next_u64());
+//! ```
+
+use rand_core::{Error, RngCore, impls};
+
+/// A fast, deterministic 64-bit xorshift PRNG.
+///
+/// Suitable for simulation use where reproducibility from a seed matters
+/// more than cryptographic strength. Seed 0 is mapped to 1 to avoid the
+/// fixed point.
+#[derive(Clone, Copy)]
+pub struct Xorshift64(u64);
+
+impl Xorshift64 {
+    pub fn new(seed: u64) -> Self {
+        Self(if seed == 0 { 1 } else { seed })
+    }
+}
+
+impl RngCore for Xorshift64 {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_next(self, dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn seed_zero_becomes_one() {
+        let mut a = Xorshift64::new(0);
+        let mut b = Xorshift64::new(1);
+        assert_eq!(a.next_u64(), b.next_u64());
+    }
+
+    #[test]
+    fn deterministic_sequence() {
+        let mut a = Xorshift64::new(42);
+        let mut b = Xorshift64::new(42);
+        for _ in 0..100 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn nonzero_output() {
+        let mut rng = Xorshift64::new(1);
+        for _ in 0..1000 {
+            assert_ne!(rng.next_u64(), 0);
+        }
+    }
+
+    #[test]
+    fn fill_bytes_deterministic() {
+        let mut a = Xorshift64::new(7);
+        let mut b = Xorshift64::new(7);
+        let mut buf_a = [0u8; 16];
+        let mut buf_b = [0u8; 16];
+        a.fill_bytes(&mut buf_a);
+        b.fill_bytes(&mut buf_b);
+        assert_eq!(buf_a, buf_b);
+    }
+
+    /// Pins the exact output sequence for seed 1 against the (<<13, >>7, <<17) triplet.
+    /// Any accidental change to the shift constants will break this test, protecting
+    /// the reproducibility guarantee for saved simulation seeds.
+    #[test]
+    fn known_sequence() {
+        let mut rng = Xorshift64::new(1);
+        assert_eq!(rng.next_u64(), 1_082_269_761);
+        assert_eq!(rng.next_u64(), 1_152_992_998_833_853_505);
+        assert_eq!(rng.next_u64(), 11_177_516_664_432_764_457);
+    }
+
+    /// `next_u32` truncates the upper 32 bits of `next_u64`.
+    #[test]
+    fn next_u32_consistent_with_next_u64() {
+        let mut rng_u32 = Xorshift64::new(5);
+        let mut rng_u64 = Xorshift64::new(5);
+        // next_u32 must equal the low 32 bits of next_u64
+        assert_eq!(rng_u32.next_u32(), rng_u64.next_u64() as u32);
+    }
+
+    /// `try_fill_bytes` must succeed and produce the same bytes as `fill_bytes`.
+    #[test]
+    fn try_fill_bytes_matches_fill_bytes() {
+        let mut a = Xorshift64::new(9);
+        let mut b = Xorshift64::new(9);
+        let mut buf_a = [0u8; 16];
+        let mut buf_b = [0u8; 16];
+        a.try_fill_bytes(&mut buf_a)
+            .expect("try_fill_bytes should never fail");
+        b.fill_bytes(&mut buf_b);
+        assert_eq!(buf_a, buf_b);
+    }
+
+    proptest! {
+        #[test]
+        fn nonzero_seed_produces_nonzero_first(seed in 1u64..u64::MAX) {
+            let mut rng = Xorshift64::new(seed);
+            prop_assert_ne!(rng.next_u64(), 0);
+        }
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -91,6 +91,9 @@ pub struct Scheduler {
 impl Scheduler {
     /// Create a new scheduler that will stop at `end_time` microseconds.
     ///
+    /// Uses LoRa default channel parameters. To use a different protocol's
+    /// physical-layer parameters, see [`Scheduler::with_channel`].
+    ///
     /// # Examples
     ///
     /// ```
@@ -99,9 +102,33 @@ impl Scheduler {
     /// assert_eq!(sched.current_time(), 0);
     /// ```
     pub fn new(end_time: SimTime) -> Self {
+        Self::with_channel(end_time, Channel::new())
+    }
+
+    /// Create a new scheduler with a custom [`Channel`].
+    ///
+    /// Use this to simulate protocols other than LoRa by supplying a
+    /// [`Channel`] constructed with [`Channel::with_config`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::channel::{Channel, ChannelConfig};
+    /// use theatron::scheduler::Scheduler;
+    ///
+    /// // 802.15.4-like parameters
+    /// let channel = Channel::with_config(ChannelConfig {
+    ///     path_loss_db: 80.0,
+    ///     noise_floor_dbm: -100.0,
+    ///     co_channel_rejection_db: 3.0,
+    /// });
+    /// let sched = Scheduler::with_channel(1_000_000, channel);
+    /// assert_eq!(sched.current_time(), 0);
+    /// ```
+    pub fn with_channel(end_time: SimTime, channel: Channel) -> Self {
         Self {
             events: BinaryHeap::new(),
-            channel: Channel::new(),
+            channel,
             nodes: Vec::new(),
             interferers: Vec::new(),
             metrics: MetricsCollector::new(),
@@ -196,26 +223,27 @@ impl Scheduler {
                 if captured {
                     self.metrics.record_capture();
                 }
-                let mut wakes = Vec::new();
+                // First pass: call on_receive on every non-sender node and
+                // collect (index, optional_wake) so we can call self.schedule
+                // and self.handle_poll_transmit in a second pass without
+                // holding a borrow on self.nodes.
+                let mut receiver_results: Vec<(usize, Option<SimTime>)> = Vec::new();
                 for i in 0..self.nodes.len() {
                     if self.nodes[i].node_id() != sender {
+                        let node_id = self.nodes[i].node_id();
                         let next = self.nodes[i].on_receive(frame.clone(), time);
-                        self.metrics.record_rx(self.nodes[i].node_id());
-                        if let Some(t) = next {
-                            wakes.push((self.nodes[i].node_id(), t));
-                        }
+                        self.metrics.record_rx(node_id);
+                        receiver_results.push((i, next));
                     }
                 }
-                for (node_id, t) in wakes {
-                    self.schedule(t, EventKind::Wake { node_id });
-                }
-                let mut tx_node_idxs = Vec::new();
-                for i in 0..self.nodes.len() {
-                    if self.nodes[i].node_id() != sender {
-                        tx_node_idxs.push(i);
+                // Second pass: schedule any requested wakes and poll for
+                // follow-on transmissions using only indices and wake times
+                // already captured — no second Vec needed.
+                for (i, wake) in receiver_results {
+                    if let Some(t) = wake {
+                        let node_id = self.nodes[i].node_id();
+                        self.schedule(t, EventKind::Wake { node_id });
                     }
-                }
-                for i in tx_node_idxs {
                     self.handle_poll_transmit(i, time);
                 }
             }
@@ -316,6 +344,7 @@ impl Scheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::channel::ChannelConfig;
     use crate::types::{ChannelEvent, Transmission};
     use proptest::prelude::*;
 
@@ -714,6 +743,81 @@ mod tests {
 
         assert!(sched.metrics.total_collisions > 0);
         assert_eq!(sched.metrics.total_rx, 0, "collision prevents delivery");
+    }
+
+    /// Verify that `Scheduler::with_channel` propagates custom physical-layer
+    /// parameters: a strict capture threshold (10 dB) means a 6 dB delta that
+    /// would survive on the default LoRa channel instead collides.
+    #[test]
+    fn with_channel_uses_custom_config() {
+        let strict_channel = Channel::with_config(ChannelConfig {
+            path_loss_db: 100.0,
+            noise_floor_dbm: -117.0,
+            co_channel_rejection_db: 10.0, // stricter than LoRa default of 6 dB
+        });
+
+        // With the default LoRa channel (threshold=6), delta=6 → strong survives.
+        let mut sched_lora = Scheduler::new(200_000);
+        let mut strong_lora = SimpleNode::new(1);
+        strong_lora.queue_tx(Transmission {
+            payload: vec![0xAB],
+            sf: 7,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency: 868_100_000,
+            duration_us: 50_000,
+            tx_power_dbm: 20,
+        });
+        let mut weak_lora = SimpleNode::new(2);
+        weak_lora.queue_tx(Transmission {
+            payload: vec![0xCD],
+            sf: 7,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency: 868_100_000,
+            duration_us: 50_000,
+            tx_power_dbm: 14,
+        });
+        sched_lora.add_node(Box::new(strong_lora), Some(0));
+        sched_lora.add_node(Box::new(weak_lora), Some(10_000));
+        sched_lora.add_node(Box::new(SimpleNode::new(3)), None);
+        sched_lora.run();
+
+        // With the strict channel (threshold=10), delta=6 → both collide.
+        let mut sched_strict = Scheduler::with_channel(200_000, strict_channel);
+        let mut strong_strict = SimpleNode::new(1);
+        strong_strict.queue_tx(Transmission {
+            payload: vec![0xAB],
+            sf: 7,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency: 868_100_000,
+            duration_us: 50_000,
+            tx_power_dbm: 20,
+        });
+        let mut weak_strict = SimpleNode::new(2);
+        weak_strict.queue_tx(Transmission {
+            payload: vec![0xCD],
+            sf: 7,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency: 868_100_000,
+            duration_us: 50_000,
+            tx_power_dbm: 14,
+        });
+        sched_strict.add_node(Box::new(strong_strict), Some(0));
+        sched_strict.add_node(Box::new(weak_strict), Some(10_000));
+        sched_strict.add_node(Box::new(SimpleNode::new(3)), None);
+        sched_strict.run();
+
+        assert_eq!(
+            sched_lora.metrics.total_rx, 2,
+            "LoRa channel: strong signal captured, delivered to both other nodes"
+        );
+        assert_eq!(
+            sched_strict.metrics.total_rx, 0,
+            "strict channel: delta=6 < threshold=10, both collide, nothing delivered"
+        );
     }
 
     proptest! {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -91,9 +91,6 @@ pub struct Scheduler {
 impl Scheduler {
     /// Create a new scheduler that will stop at `end_time` microseconds.
     ///
-    /// Uses LoRa default channel parameters. To use a different protocol's
-    /// physical-layer parameters, see [`Scheduler::with_channel`].
-    ///
     /// # Examples
     ///
     /// ```
@@ -102,33 +99,9 @@ impl Scheduler {
     /// assert_eq!(sched.current_time(), 0);
     /// ```
     pub fn new(end_time: SimTime) -> Self {
-        Self::with_channel(end_time, Channel::new())
-    }
-
-    /// Create a new scheduler with a custom [`Channel`].
-    ///
-    /// Use this to simulate protocols other than LoRa by supplying a
-    /// [`Channel`] constructed with [`Channel::with_config`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::channel::{Channel, ChannelConfig};
-    /// use theatron::scheduler::Scheduler;
-    ///
-    /// // 802.15.4-like parameters
-    /// let channel = Channel::with_config(ChannelConfig {
-    ///     path_loss_db: 80.0,
-    ///     noise_floor_dbm: -100.0,
-    ///     co_channel_rejection_db: 3.0,
-    /// });
-    /// let sched = Scheduler::with_channel(1_000_000, channel);
-    /// assert_eq!(sched.current_time(), 0);
-    /// ```
-    pub fn with_channel(end_time: SimTime, channel: Channel) -> Self {
         Self {
             events: BinaryHeap::new(),
-            channel,
+            channel: Channel::new(),
             nodes: Vec::new(),
             interferers: Vec::new(),
             metrics: MetricsCollector::new(),
@@ -223,27 +196,31 @@ impl Scheduler {
                 if captured {
                     self.metrics.record_capture();
                 }
-                // First pass: call on_receive on every non-sender node and
-                // collect (index, optional_wake) so we can call self.schedule
-                // and self.handle_poll_transmit in a second pass without
-                // holding a borrow on self.nodes.
-                let mut receiver_results: Vec<(usize, Option<SimTime>)> = Vec::new();
+                let mut wakes = Vec::new();
                 for i in 0..self.nodes.len() {
                     if self.nodes[i].node_id() != sender {
-                        let node_id = self.nodes[i].node_id();
                         let next = self.nodes[i].on_receive(frame.clone(), time);
-                        self.metrics.record_rx(node_id);
-                        receiver_results.push((i, next));
+                        // record_rx counts physical-layer deliveries: every
+                        // non-sender node in the simulation is assumed to be
+                        // within radio range and receives the frame at the
+                        // physical layer, regardless of whether on_receive
+                        // returns Some (application consumed) or None (ignored).
+                        self.metrics.record_rx(self.nodes[i].node_id());
+                        if let Some(t) = next {
+                            wakes.push((self.nodes[i].node_id(), t));
+                        }
                     }
                 }
-                // Second pass: schedule any requested wakes and poll for
-                // follow-on transmissions using only indices and wake times
-                // already captured — no second Vec needed.
-                for (i, wake) in receiver_results {
-                    if let Some(t) = wake {
-                        let node_id = self.nodes[i].node_id();
-                        self.schedule(t, EventKind::Wake { node_id });
+                for (node_id, t) in wakes {
+                    self.schedule(t, EventKind::Wake { node_id });
+                }
+                let mut tx_node_idxs = Vec::new();
+                for i in 0..self.nodes.len() {
+                    if self.nodes[i].node_id() != sender {
+                        tx_node_idxs.push(i);
                     }
+                }
+                for i in tx_node_idxs {
                     self.handle_poll_transmit(i, time);
                 }
             }
@@ -344,7 +321,6 @@ impl Scheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::channel::ChannelConfig;
     use crate::types::{ChannelEvent, Transmission};
     use proptest::prelude::*;
 
@@ -743,81 +719,6 @@ mod tests {
 
         assert!(sched.metrics.total_collisions > 0);
         assert_eq!(sched.metrics.total_rx, 0, "collision prevents delivery");
-    }
-
-    /// Verify that `Scheduler::with_channel` propagates custom physical-layer
-    /// parameters: a strict capture threshold (10 dB) means a 6 dB delta that
-    /// would survive on the default LoRa channel instead collides.
-    #[test]
-    fn with_channel_uses_custom_config() {
-        let strict_channel = Channel::with_config(ChannelConfig {
-            path_loss_db: 100.0,
-            noise_floor_dbm: -117.0,
-            co_channel_rejection_db: 10.0, // stricter than LoRa default of 6 dB
-        });
-
-        // With the default LoRa channel (threshold=6), delta=6 → strong survives.
-        let mut sched_lora = Scheduler::new(200_000);
-        let mut strong_lora = SimpleNode::new(1);
-        strong_lora.queue_tx(Transmission {
-            payload: vec![0xAB],
-            sf: 7,
-            bandwidth: 125_000,
-            coding_rate: 5,
-            frequency: 868_100_000,
-            duration_us: 50_000,
-            tx_power_dbm: 20,
-        });
-        let mut weak_lora = SimpleNode::new(2);
-        weak_lora.queue_tx(Transmission {
-            payload: vec![0xCD],
-            sf: 7,
-            bandwidth: 125_000,
-            coding_rate: 5,
-            frequency: 868_100_000,
-            duration_us: 50_000,
-            tx_power_dbm: 14,
-        });
-        sched_lora.add_node(Box::new(strong_lora), Some(0));
-        sched_lora.add_node(Box::new(weak_lora), Some(10_000));
-        sched_lora.add_node(Box::new(SimpleNode::new(3)), None);
-        sched_lora.run();
-
-        // With the strict channel (threshold=10), delta=6 → both collide.
-        let mut sched_strict = Scheduler::with_channel(200_000, strict_channel);
-        let mut strong_strict = SimpleNode::new(1);
-        strong_strict.queue_tx(Transmission {
-            payload: vec![0xAB],
-            sf: 7,
-            bandwidth: 125_000,
-            coding_rate: 5,
-            frequency: 868_100_000,
-            duration_us: 50_000,
-            tx_power_dbm: 20,
-        });
-        let mut weak_strict = SimpleNode::new(2);
-        weak_strict.queue_tx(Transmission {
-            payload: vec![0xCD],
-            sf: 7,
-            bandwidth: 125_000,
-            coding_rate: 5,
-            frequency: 868_100_000,
-            duration_us: 50_000,
-            tx_power_dbm: 14,
-        });
-        sched_strict.add_node(Box::new(strong_strict), Some(0));
-        sched_strict.add_node(Box::new(weak_strict), Some(10_000));
-        sched_strict.add_node(Box::new(SimpleNode::new(3)), None);
-        sched_strict.run();
-
-        assert_eq!(
-            sched_lora.metrics.total_rx, 2,
-            "LoRa channel: strong signal captured, delivered to both other nodes"
-        );
-        assert_eq!(
-            sched_strict.metrics.total_rx, 0,
-            "strict channel: delta=6 < threshold=10, both collide, nothing delivered"
-        );
     }
 
     proptest! {

--- a/tests/aloha.rs
+++ b/tests/aloha.rs
@@ -1,0 +1,323 @@
+//! Integration tests for the Pure ALOHA reference protocol.
+//!
+//! Three tests:
+//!   1. `single_node_delivery`    — one sender, one packet → received.
+//!   2. `multi_node_collision`    — two simultaneous senders → collision.
+//!   3. `backoff_retransmission`  — backoff actually delays the next TX.
+
+use theatron::aloha::{AlohaNode, PoissonTraffic, LORA_SF7_DURATION_US};
+use theatron::scheduler::{NodeHandle, Scheduler};
+use theatron::time::SimTime;
+use theatron::traits::TrafficModel;
+use theatron::types::{NodeId, RxMetadata, Transmission};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A traffic model that fires exactly once at `fire_at` µs.
+struct FireOnce {
+    payload: Vec<u8>,
+    fire_at: SimTime,
+    fired: bool,
+}
+
+impl FireOnce {
+    fn new(payload: Vec<u8>, fire_at: SimTime) -> Self {
+        Self {
+            payload,
+            fire_at,
+            fired: false,
+        }
+    }
+}
+
+impl TrafficModel for FireOnce {
+    fn next_payload(&mut self, time: SimTime) -> Option<Vec<u8>> {
+        if !self.fired && time >= self.fire_at {
+            self.fired = true;
+            Some(self.payload.clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// A pure receiver node that counts received frames.
+struct Receiver {
+    id: NodeId,
+    pub rx_count: usize,
+}
+
+impl Receiver {
+    fn new(id: u32) -> Self {
+        Self {
+            id: NodeId(id),
+            rx_count: 0,
+        }
+    }
+}
+
+impl NodeHandle for Receiver {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+    fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+        self.rx_count += 1;
+        None
+    }
+    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+        None
+    }
+    fn update(&mut self, _time: SimTime) -> Option<SimTime> {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: single_node_delivery
+// ---------------------------------------------------------------------------
+
+/// One sender fires exactly one packet; the single receiver must receive it.
+#[test]
+fn single_node_delivery() {
+    // Simulation long enough for the TX to complete (SF7 ≈ 56 ms).
+    let sim_end = LORA_SF7_DURATION_US * 10;
+    let mut scheduler = Scheduler::new(sim_end);
+
+    // Node fires at t=0.
+    let traffic = FireOnce::new(vec![0xAB], 0);
+    let sender = AlohaNode::new(NodeId(1), traffic, 0, 1);
+    scheduler.add_node(Box::new(sender), Some(0));
+    scheduler.add_node(Box::new(Receiver::new(2)), None);
+
+    scheduler.run();
+
+    assert_eq!(scheduler.metrics.total_tx, 1, "exactly one TX expected");
+    assert_eq!(
+        scheduler.metrics.total_rx, 1,
+        "single packet must be delivered to the receiver"
+    );
+    assert_eq!(
+        scheduler.metrics.total_collisions, 0,
+        "no collision with a single sender"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: multi_node_collision
+// ---------------------------------------------------------------------------
+
+/// Two senders transmit at the same time on the same channel; the channel
+/// model must detect the collision (both frames collided, zero deliveries).
+#[test]
+fn multi_node_collision() {
+    let sim_end = LORA_SF7_DURATION_US * 10;
+    let mut scheduler = Scheduler::new(sim_end);
+
+    // Both nodes fire at t=0 → their TX start times coincide exactly.
+    let t1 = FireOnce::new(vec![0x01], 0);
+    let t2 = FireOnce::new(vec![0x02], 0);
+
+    scheduler.add_node(
+        Box::new(AlohaNode::new(NodeId(1), t1, 0, 10)),
+        Some(0),
+    );
+    scheduler.add_node(
+        Box::new(AlohaNode::new(NodeId(2), t2, 0, 20)),
+        Some(0),
+    );
+    scheduler.add_node(Box::new(Receiver::new(3)), None);
+
+    scheduler.run();
+
+    assert_eq!(scheduler.metrics.total_tx, 2, "both nodes must transmit");
+    assert!(
+        scheduler.metrics.total_collisions >= 2,
+        "both concurrent same-SF/freq TXs must collide; got {}",
+        scheduler.metrics.total_collisions
+    );
+    assert_eq!(
+        scheduler.metrics.total_rx, 0,
+        "no frame must be delivered when both collide"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: backoff_retransmission
+// ---------------------------------------------------------------------------
+
+/// A node with a two-packet traffic model and a non-zero backoff must wait
+/// at least one µs between the first and second TX, demonstrating that the
+/// backoff mechanism actually delays the next transmission.
+///
+/// We use a large backoff window (1 s) and a short simulation window so we
+/// can verify that the second TX happens strictly after the first TX plus
+/// the TX duration, but within the simulation window.
+#[test]
+fn backoff_retransmission() {
+    // Traffic model that fires twice: at t=0 and immediately after the first
+    // arrival has been consumed.
+    struct TwoShot(u8);
+    impl TrafficModel for TwoShot {
+        fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
+            if self.0 > 0 {
+                self.0 -= 1;
+                Some(vec![self.0])
+            } else {
+                None
+            }
+        }
+    }
+
+    // Backoff window: up to 200 ms.  With a fixed seed the backoff will be
+    // deterministic and somewhere in [0, 200_000).
+    let backoff_range_us = 200_000u64;
+    // Run long enough for two TXs + maximum backoff.
+    let sim_end = LORA_SF7_DURATION_US * 2 + backoff_range_us + 100_000;
+    let mut scheduler = Scheduler::new(sim_end);
+
+    // Instrument: we want to know *when* each TX was issued.  We wrap the
+    // AlohaNode logic in a thin recording shim.
+    struct RecordingNode<T: TrafficModel> {
+        inner: AlohaNode<T>,
+        tx_times: Vec<SimTime>,
+    }
+
+    impl<T: TrafficModel> NodeHandle for RecordingNode<T> {
+        fn node_id(&self) -> NodeId {
+            self.inner.node_id()
+        }
+        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+            self.inner.on_receive(frame, time)
+        }
+        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+            let tx = self.inner.poll_transmit(time);
+            if tx.is_some() {
+                self.tx_times.push(time);
+            }
+            tx
+        }
+        fn update(&mut self, time: SimTime) -> Option<SimTime> {
+            self.inner.update(time)
+        }
+    }
+
+    let node = RecordingNode {
+        inner: AlohaNode::new(NodeId(1), TwoShot(2), backoff_range_us, 42),
+        tx_times: Vec::new(),
+    };
+
+    let node_ptr = scheduler.add_node_returning(Box::new(node), Some(0));
+    drop(node_ptr); // add_node_returning doesn't exist — use metrics instead.
+
+    // Because we can't observe internal state after `run()` (nodes are
+    // boxed), we verify the timing indirectly via the metrics:
+    //  - exactly 2 TXs must occur
+    //  - the second TX must happen strictly after the first TX + TX_duration
+    //    (i.e. total_airtime must be 2 × LORA_SF7_DURATION_US, not 1)
+    //
+    // To get per-TX timestamps we use a different approach: instrument via
+    // a custom NodeHandle that exposes tx_times after the run.
+
+    // Reset and re-run with a standalone recorder that we can inspect.
+    struct StandaloneRecorder {
+        inner: AlohaNode<TwoShot>,
+        pub tx_times: Vec<SimTime>,
+    }
+
+    impl NodeHandle for StandaloneRecorder {
+        fn node_id(&self) -> NodeId {
+            self.inner.node_id()
+        }
+        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+            self.inner.on_receive(frame, time)
+        }
+        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+            let tx = self.inner.poll_transmit(time);
+            if tx.is_some() {
+                self.tx_times.push(time);
+            }
+            tx
+        }
+        fn update(&mut self, time: SimTime) -> Option<SimTime> {
+            self.inner.update(time)
+        }
+    }
+
+    let recorder = StandaloneRecorder {
+        inner: AlohaNode::new(NodeId(1), TwoShot(2), backoff_range_us, 42),
+        tx_times: Vec::new(),
+    };
+
+    // We need to get the recorder back out after the run. Scheduler stores
+    // nodes as Box<dyn NodeHandle>, so we use a raw-pointer trick via a
+    // shared cell.
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    // Instead, use an Rc<RefCell<...>> wrapper so we can read tx_times later.
+    struct SharedRecorder {
+        inner: AlohaNode<TwoShot>,
+        tx_times: Rc<RefCell<Vec<SimTime>>>,
+    }
+
+    impl NodeHandle for SharedRecorder {
+        fn node_id(&self) -> NodeId {
+            self.inner.node_id()
+        }
+        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+            self.inner.on_receive(frame, time)
+        }
+        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+            let tx = self.inner.poll_transmit(time);
+            if tx.is_some() {
+                self.tx_times.borrow_mut().push(time);
+            }
+            tx
+        }
+        fn update(&mut self, time: SimTime) -> Option<SimTime> {
+            self.inner.update(time)
+        }
+    }
+
+    let tx_times: Rc<RefCell<Vec<SimTime>>> = Rc::new(RefCell::new(Vec::new()));
+    let tx_times_out = Rc::clone(&tx_times);
+
+    let mut scheduler2 = Scheduler::new(sim_end);
+    scheduler2.add_node(
+        Box::new(SharedRecorder {
+            inner: AlohaNode::new(NodeId(1), TwoShot(2), backoff_range_us, 42),
+            tx_times,
+        }),
+        Some(0),
+    );
+    scheduler2.add_node(Box::new(Receiver::new(2)), None);
+    scheduler2.run();
+
+    let times = tx_times_out.borrow();
+    assert_eq!(
+        times.len(),
+        2,
+        "two-shot traffic must produce exactly two TXs; got {}",
+        times.len()
+    );
+    assert!(
+        times[1] > times[0],
+        "second TX ({}) must happen after first TX ({})",
+        times[1],
+        times[0]
+    );
+    // Backoff ≥ 0 but the node must at least wait for the TX duration.
+    assert!(
+        times[1] >= times[0] + LORA_SF7_DURATION_US,
+        "second TX must be at least one TX-duration after the first; \
+         first={} second={} duration={}",
+        times[0],
+        times[1],
+        LORA_SF7_DURATION_US
+    );
+
+    // Sanity: total_tx and total_rx match expectations.
+    assert_eq!(scheduler2.metrics.total_tx, 2);
+}

--- a/tests/aloha.rs
+++ b/tests/aloha.rs
@@ -5,6 +5,9 @@
 //!   2. `multi_node_collision`    — two simultaneous senders → collision.
 //!   3. `backoff_retransmission`  — backoff actually delays the next TX.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use theatron::aloha::{AlohaNode, PoissonTraffic, LORA_SF7_DURATION_US};
 use theatron::scheduler::{NodeHandle, Scheduler};
 use theatron::time::SimTime;
@@ -12,10 +15,10 @@ use theatron::traits::TrafficModel;
 use theatron::types::{NodeId, RxMetadata, Transmission};
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Shared helpers
 // ---------------------------------------------------------------------------
 
-/// A traffic model that fires exactly once at `fire_at` µs.
+/// A traffic model that fires exactly once when `time >= fire_at`.
 struct FireOnce {
     payload: Vec<u8>,
     fire_at: SimTime,
@@ -46,15 +49,11 @@ impl TrafficModel for FireOnce {
 /// A pure receiver node that counts received frames.
 struct Receiver {
     id: NodeId,
-    pub rx_count: usize,
 }
 
 impl Receiver {
     fn new(id: u32) -> Self {
-        Self {
-            id: NodeId(id),
-            rx_count: 0,
-        }
+        Self { id: NodeId(id) }
     }
 }
 
@@ -63,7 +62,6 @@ impl NodeHandle for Receiver {
         self.id
     }
     fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
-        self.rx_count += 1;
         None
     }
     fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
@@ -74,6 +72,47 @@ impl NodeHandle for Receiver {
     }
 }
 
+/// Traffic model that fires exactly `n` times, one payload per poll.
+struct NShot(u8);
+
+impl TrafficModel for NShot {
+    fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
+        if self.0 > 0 {
+            self.0 -= 1;
+            Some(vec![self.0])
+        } else {
+            None
+        }
+    }
+}
+
+/// Wraps an `AlohaNode` and records the simulation time of each TX via a
+/// shared `Rc<RefCell<Vec<SimTime>>>` so callers can inspect timings after
+/// `scheduler.run()` consumes the boxed node.
+struct RecordingNode<T: TrafficModel> {
+    inner: AlohaNode<T>,
+    tx_times: Rc<RefCell<Vec<SimTime>>>,
+}
+
+impl<T: TrafficModel> NodeHandle for RecordingNode<T> {
+    fn node_id(&self) -> NodeId {
+        self.inner.node_id()
+    }
+    fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+        self.inner.on_receive(frame, time)
+    }
+    fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+        let tx = self.inner.poll_transmit(time);
+        if tx.is_some() {
+            self.tx_times.borrow_mut().push(time);
+        }
+        tx
+    }
+    fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        self.inner.update(time)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: single_node_delivery
 // ---------------------------------------------------------------------------
@@ -81,11 +120,9 @@ impl NodeHandle for Receiver {
 /// One sender fires exactly one packet; the single receiver must receive it.
 #[test]
 fn single_node_delivery() {
-    // Simulation long enough for the TX to complete (SF7 ≈ 56 ms).
     let sim_end = LORA_SF7_DURATION_US * 10;
     let mut scheduler = Scheduler::new(sim_end);
 
-    // Node fires at t=0.
     let traffic = FireOnce::new(vec![0xAB], 0);
     let sender = AlohaNode::new(NodeId(1), traffic, 0, 1);
     scheduler.add_node(Box::new(sender), Some(0));
@@ -108,23 +145,31 @@ fn single_node_delivery() {
 // Test 2: multi_node_collision
 // ---------------------------------------------------------------------------
 
-/// Two senders transmit at the same time on the same channel; the channel
-/// model must detect the collision (both frames collided, zero deliveries).
+/// Two senders transmit at the same time on the same SF/frequency; the
+/// channel model must detect the collision (both frames collided, zero
+/// deliveries).
 #[test]
 fn multi_node_collision() {
     let sim_end = LORA_SF7_DURATION_US * 10;
     let mut scheduler = Scheduler::new(sim_end);
 
-    // Both nodes fire at t=0 → their TX start times coincide exactly.
-    let t1 = FireOnce::new(vec![0x01], 0);
-    let t2 = FireOnce::new(vec![0x02], 0);
-
+    // Both nodes fire at t=0 → TX start times coincide exactly.
     scheduler.add_node(
-        Box::new(AlohaNode::new(NodeId(1), t1, 0, 10)),
+        Box::new(AlohaNode::new(
+            NodeId(1),
+            FireOnce::new(vec![0x01], 0),
+            0,
+            10,
+        )),
         Some(0),
     );
     scheduler.add_node(
-        Box::new(AlohaNode::new(NodeId(2), t2, 0, 20)),
+        Box::new(AlohaNode::new(
+            NodeId(2),
+            FireOnce::new(vec![0x02], 0),
+            0,
+            20,
+        )),
         Some(0),
     );
     scheduler.add_node(Box::new(Receiver::new(3)), None);
@@ -147,153 +192,29 @@ fn multi_node_collision() {
 // Test 3: backoff_retransmission
 // ---------------------------------------------------------------------------
 
-/// A node with a two-packet traffic model and a non-zero backoff must wait
-/// at least one µs between the first and second TX, demonstrating that the
-/// backoff mechanism actually delays the next transmission.
-///
-/// We use a large backoff window (1 s) and a short simulation window so we
-/// can verify that the second TX happens strictly after the first TX plus
-/// the TX duration, but within the simulation window.
+/// A node with two queued payloads and a non-zero backoff window must place
+/// its second TX strictly after the first TX, and that gap must be at least
+/// the on-air duration of the first packet.
 #[test]
 fn backoff_retransmission() {
-    // Traffic model that fires twice: at t=0 and immediately after the first
-    // arrival has been consumed.
-    struct TwoShot(u8);
-    impl TrafficModel for TwoShot {
-        fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
-            if self.0 > 0 {
-                self.0 -= 1;
-                Some(vec![self.0])
-            } else {
-                None
-            }
-        }
-    }
-
-    // Backoff window: up to 200 ms.  With a fixed seed the backoff will be
-    // deterministic and somewhere in [0, 200_000).
+    // Backoff window: up to 200 ms.
     let backoff_range_us = 200_000u64;
-    // Run long enough for two TXs + maximum backoff.
+    // Give enough time for 2 TXs + max backoff.
     let sim_end = LORA_SF7_DURATION_US * 2 + backoff_range_us + 100_000;
-    let mut scheduler = Scheduler::new(sim_end);
-
-    // Instrument: we want to know *when* each TX was issued.  We wrap the
-    // AlohaNode logic in a thin recording shim.
-    struct RecordingNode<T: TrafficModel> {
-        inner: AlohaNode<T>,
-        tx_times: Vec<SimTime>,
-    }
-
-    impl<T: TrafficModel> NodeHandle for RecordingNode<T> {
-        fn node_id(&self) -> NodeId {
-            self.inner.node_id()
-        }
-        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
-            self.inner.on_receive(frame, time)
-        }
-        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
-            let tx = self.inner.poll_transmit(time);
-            if tx.is_some() {
-                self.tx_times.push(time);
-            }
-            tx
-        }
-        fn update(&mut self, time: SimTime) -> Option<SimTime> {
-            self.inner.update(time)
-        }
-    }
-
-    let node = RecordingNode {
-        inner: AlohaNode::new(NodeId(1), TwoShot(2), backoff_range_us, 42),
-        tx_times: Vec::new(),
-    };
-
-    let node_ptr = scheduler.add_node_returning(Box::new(node), Some(0));
-    drop(node_ptr); // add_node_returning doesn't exist — use metrics instead.
-
-    // Because we can't observe internal state after `run()` (nodes are
-    // boxed), we verify the timing indirectly via the metrics:
-    //  - exactly 2 TXs must occur
-    //  - the second TX must happen strictly after the first TX + TX_duration
-    //    (i.e. total_airtime must be 2 × LORA_SF7_DURATION_US, not 1)
-    //
-    // To get per-TX timestamps we use a different approach: instrument via
-    // a custom NodeHandle that exposes tx_times after the run.
-
-    // Reset and re-run with a standalone recorder that we can inspect.
-    struct StandaloneRecorder {
-        inner: AlohaNode<TwoShot>,
-        pub tx_times: Vec<SimTime>,
-    }
-
-    impl NodeHandle for StandaloneRecorder {
-        fn node_id(&self) -> NodeId {
-            self.inner.node_id()
-        }
-        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
-            self.inner.on_receive(frame, time)
-        }
-        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
-            let tx = self.inner.poll_transmit(time);
-            if tx.is_some() {
-                self.tx_times.push(time);
-            }
-            tx
-        }
-        fn update(&mut self, time: SimTime) -> Option<SimTime> {
-            self.inner.update(time)
-        }
-    }
-
-    let recorder = StandaloneRecorder {
-        inner: AlohaNode::new(NodeId(1), TwoShot(2), backoff_range_us, 42),
-        tx_times: Vec::new(),
-    };
-
-    // We need to get the recorder back out after the run. Scheduler stores
-    // nodes as Box<dyn NodeHandle>, so we use a raw-pointer trick via a
-    // shared cell.
-    use std::cell::RefCell;
-    use std::rc::Rc;
-
-    // Instead, use an Rc<RefCell<...>> wrapper so we can read tx_times later.
-    struct SharedRecorder {
-        inner: AlohaNode<TwoShot>,
-        tx_times: Rc<RefCell<Vec<SimTime>>>,
-    }
-
-    impl NodeHandle for SharedRecorder {
-        fn node_id(&self) -> NodeId {
-            self.inner.node_id()
-        }
-        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
-            self.inner.on_receive(frame, time)
-        }
-        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
-            let tx = self.inner.poll_transmit(time);
-            if tx.is_some() {
-                self.tx_times.borrow_mut().push(time);
-            }
-            tx
-        }
-        fn update(&mut self, time: SimTime) -> Option<SimTime> {
-            self.inner.update(time)
-        }
-    }
 
     let tx_times: Rc<RefCell<Vec<SimTime>>> = Rc::new(RefCell::new(Vec::new()));
     let tx_times_out = Rc::clone(&tx_times);
 
-    let mut scheduler2 = Scheduler::new(sim_end);
-    scheduler2.add_node(
-        Box::new(SharedRecorder {
-            inner: AlohaNode::new(NodeId(1), TwoShot(2), backoff_range_us, 42),
+    let mut scheduler = Scheduler::new(sim_end);
+    scheduler.add_node(
+        Box::new(RecordingNode {
+            inner: AlohaNode::new(NodeId(1), NShot(2), backoff_range_us, 42),
             tx_times,
         }),
         Some(0),
     );
-    scheduler2.add_node(Box::new(Receiver::new(2)), None);
-    scheduler2.run();
+    scheduler.add_node(Box::new(Receiver::new(2)), None);
+    scheduler.run();
 
     let times = tx_times_out.borrow();
     assert_eq!(
@@ -308,7 +229,8 @@ fn backoff_retransmission() {
         times[1],
         times[0]
     );
-    // Backoff ≥ 0 but the node must at least wait for the TX duration.
+    // The node cannot re-transmit until after the first packet has been on
+    // air (TX duration) plus any backoff time (≥ 0).
     assert!(
         times[1] >= times[0] + LORA_SF7_DURATION_US,
         "second TX must be at least one TX-duration after the first; \
@@ -318,6 +240,6 @@ fn backoff_retransmission() {
         LORA_SF7_DURATION_US
     );
 
-    // Sanity: total_tx and total_rx match expectations.
-    assert_eq!(scheduler2.metrics.total_tx, 2);
+    // Sanity: total_tx matches.
+    assert_eq!(scheduler.metrics.total_tx, 2);
 }

--- a/tests/aloha.rs
+++ b/tests/aloha.rs
@@ -1,260 +1,514 @@
-//! Integration tests for the Pure ALOHA reference protocol.
+//! Tests for ALOHA-related behaviour.
 //!
-//! Three tests:
-//!   1. `single_node_delivery`    — one sender, one packet → received.
-//!   2. `multi_node_collision`    — two simultaneous senders → collision.
-//!   3. `backoff_retransmission`  — backoff actually delays the next TX.
+//! # Module 1 — `aloha_node` (integration tests for `AlohaNode`)
+//!
+//! Tests the `theatron::aloha::{AlohaNode, PoissonTraffic}` types directly,
+//! covering single-node delivery, multi-node collision, and backoff retransmission.
+//!
+//! # Module 2 — `scheduler_patterns` (scheduler/channel model for ALOHA-like patterns)
+//!
+//! These tests use local `PeriodicSender`/`Receiver` helpers to validate the
+//! scheduler + channel model for ALOHA-like transmission patterns (collision,
+//! SF/frequency orthogonality, capture effect). They do not depend on `AlohaNode`.
 
-use std::cell::RefCell;
-use std::rc::Rc;
+// ===========================================================================
+// Module 1: AlohaNode integration tests
+// ===========================================================================
 
-use theatron::aloha::{AlohaNode, UniformInterarrivalTraffic, LORA_SF7_DURATION_US};
-use theatron::scheduler::{NodeHandle, Scheduler};
-use theatron::time::SimTime;
-use theatron::traits::TrafficModel;
-use theatron::types::{NodeId, RxMetadata, Transmission};
+mod aloha_node {
+    use std::cell::RefCell;
+    use std::rc::Rc;
 
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
+    use theatron::aloha::{AlohaNode, PoissonTraffic, LORA_SF7_DURATION_US};
+    use theatron::scheduler::{NodeHandle, Scheduler};
+    use theatron::time::SimTime;
+    use theatron::traits::TrafficModel;
+    use theatron::types::{NodeId, RxMetadata, Transmission};
 
-/// A traffic model that fires exactly once when `time >= fire_at`.
-struct FireOnce {
-    payload: Vec<u8>,
-    fire_at: SimTime,
-    fired: bool,
+    /// A traffic model that fires exactly once when `time >= fire_at`.
+    struct FireOnce {
+        payload: Vec<u8>,
+        fire_at: SimTime,
+        fired: bool,
+    }
+
+    impl FireOnce {
+        fn new(payload: Vec<u8>, fire_at: SimTime) -> Self {
+            Self {
+                payload,
+                fire_at,
+                fired: false,
+            }
+        }
+    }
+
+    impl TrafficModel for FireOnce {
+        fn next_payload(&mut self, time: SimTime) -> Option<Vec<u8>> {
+            if !self.fired && time >= self.fire_at {
+                self.fired = true;
+                Some(self.payload.clone())
+            } else {
+                None
+            }
+        }
+    }
+
+    /// A pure receiver node that counts received frames.
+    struct Receiver {
+        id: NodeId,
+    }
+
+    impl Receiver {
+        fn new(id: u32) -> Self {
+            Self { id: NodeId(id) }
+        }
+    }
+
+    impl NodeHandle for Receiver {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+            None
+        }
+        fn update(&mut self, _time: SimTime) -> Option<SimTime> {
+            None
+        }
+    }
+
+    /// Traffic model that fires exactly `n` times, one payload per poll.
+    struct NShot(u8);
+
+    impl TrafficModel for NShot {
+        fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
+            if self.0 > 0 {
+                self.0 -= 1;
+                Some(vec![self.0])
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Wraps an `AlohaNode` and records the simulation time of each TX.
+    struct RecordingNode<T: TrafficModel> {
+        inner: AlohaNode<T>,
+        tx_times: Rc<RefCell<Vec<SimTime>>>,
+    }
+
+    impl<T: TrafficModel> NodeHandle for RecordingNode<T> {
+        fn node_id(&self) -> NodeId {
+            self.inner.node_id()
+        }
+        fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+            self.inner.on_receive(frame, time)
+        }
+        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+            let tx = self.inner.poll_transmit(time);
+            if tx.is_some() {
+                self.tx_times.borrow_mut().push(time);
+            }
+            tx
+        }
+        fn update(&mut self, time: SimTime) -> Option<SimTime> {
+            self.inner.update(time)
+        }
+    }
+
+    #[test]
+    fn single_node_delivery() {
+        let sim_end = LORA_SF7_DURATION_US * 10;
+        let mut scheduler = Scheduler::new(sim_end);
+
+        let traffic = FireOnce::new(vec![0xAB], 0);
+        let sender = AlohaNode::new(NodeId(1), traffic, 0, 1);
+        scheduler.add_node(Box::new(sender), Some(0));
+        scheduler.add_node(Box::new(Receiver::new(2)), None);
+
+        scheduler.run();
+
+        assert_eq!(scheduler.metrics.total_tx, 1, "exactly one TX expected");
+        assert_eq!(
+            scheduler.metrics.total_rx, 1,
+            "single packet must be delivered to the receiver"
+        );
+        assert_eq!(
+            scheduler.metrics.total_collisions, 0,
+            "no collision with a single sender"
+        );
+    }
+
+    #[test]
+    fn multi_node_collision() {
+        let sim_end = LORA_SF7_DURATION_US * 10;
+        let mut scheduler = Scheduler::new(sim_end);
+
+        scheduler.add_node(
+            Box::new(AlohaNode::new(
+                NodeId(1),
+                FireOnce::new(vec![0x01], 0),
+                0,
+                10,
+            )),
+            Some(0),
+        );
+        scheduler.add_node(
+            Box::new(AlohaNode::new(
+                NodeId(2),
+                FireOnce::new(vec![0x02], 0),
+                0,
+                20,
+            )),
+            Some(0),
+        );
+        scheduler.add_node(Box::new(Receiver::new(3)), None);
+
+        scheduler.run();
+
+        assert_eq!(scheduler.metrics.total_tx, 2, "both nodes must transmit");
+        assert!(
+            scheduler.metrics.total_collisions >= 2,
+            "both concurrent same-SF/freq TXs must collide; got {}",
+            scheduler.metrics.total_collisions
+        );
+        assert_eq!(
+            scheduler.metrics.total_rx, 0,
+            "no frame must be delivered when both collide"
+        );
+    }
+
+    #[test]
+    fn backoff_retransmission() {
+        let backoff_range_us = 200_000u64;
+        let sim_end = LORA_SF7_DURATION_US * 2 + backoff_range_us + 100_000;
+
+        let tx_times: Rc<RefCell<Vec<SimTime>>> = Rc::new(RefCell::new(Vec::new()));
+        let tx_times_out = Rc::clone(&tx_times);
+
+        let mut scheduler = Scheduler::new(sim_end);
+        scheduler.add_node(
+            Box::new(RecordingNode {
+                inner: AlohaNode::new(NodeId(1), NShot(2), backoff_range_us, 42),
+                tx_times,
+            }),
+            Some(0),
+        );
+        scheduler.add_node(Box::new(Receiver::new(2)), None);
+        scheduler.run();
+
+        let times = tx_times_out.borrow();
+        assert_eq!(
+            times.len(),
+            2,
+            "two-shot traffic must produce exactly two TXs; got {}",
+            times.len()
+        );
+        assert!(
+            times[1] > times[0],
+            "second TX ({}) must happen after first TX ({})",
+            times[1],
+            times[0]
+        );
+        assert!(
+            times[1] >= times[0] + LORA_SF7_DURATION_US,
+            "second TX must be at least one TX-duration after the first; \
+             first={} second={} duration={}",
+            times[0],
+            times[1],
+            LORA_SF7_DURATION_US
+        );
+        assert_eq!(scheduler.metrics.total_tx, 2);
+    }
 }
 
-impl FireOnce {
-    fn new(payload: Vec<u8>, fire_at: SimTime) -> Self {
-        Self {
+// ===========================================================================
+// Module 2: Scheduler/channel model for ALOHA-like transmission patterns
+// ===========================================================================
+
+mod scheduler_patterns {
+    use theatron::scheduler::{NodeHandle, Scheduler};
+    use theatron::time::SimTime;
+    use theatron::types::{NodeId, RxMetadata, Transmission};
+
+    fn make_tx(payload: Vec<u8>, sf: u8, frequency: u32, duration_us: u64) -> Transmission {
+        Transmission {
             payload,
-            fire_at,
-            fired: false,
+            sf,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency,
+            duration_us,
+            tx_power_dbm: 14,
         }
     }
-}
 
-impl TrafficModel for FireOnce {
-    fn next_payload(&mut self, time: SimTime) -> Option<Vec<u8>> {
-        if !self.fired && time >= self.fire_at {
-            self.fired = true;
-            Some(self.payload.clone())
-        } else {
+    fn make_tx_power(
+        payload: Vec<u8>,
+        sf: u8,
+        frequency: u32,
+        duration_us: u64,
+        tx_power_dbm: i8,
+    ) -> Transmission {
+        Transmission {
+            payload,
+            sf,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency,
+            duration_us,
+            tx_power_dbm,
+        }
+    }
+
+    struct PeriodicSender {
+        id: NodeId,
+        interval_us: u64,
+        duration_us: u64,
+        remaining: usize,
+        sf: u8,
+        frequency: u32,
+        pending: Option<Transmission>,
+    }
+
+    impl PeriodicSender {
+        fn new(
+            id: u32,
+            interval_us: u64,
+            duration_us: u64,
+            count: usize,
+            sf: u8,
+            frequency: u32,
+        ) -> Self {
+            Self {
+                id: NodeId(id),
+                interval_us,
+                duration_us,
+                remaining: count,
+                sf,
+                frequency,
+                pending: None,
+            }
+        }
+    }
+
+    impl NodeHandle for PeriodicSender {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+            self.pending.take()
+        }
+        fn update(&mut self, time: SimTime) -> Option<SimTime> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                self.pending = Some(make_tx(
+                    vec![self.id.0 as u8; 10],
+                    self.sf,
+                    self.frequency,
+                    self.duration_us,
+                ));
+                Some(time + self.interval_us)
+            } else {
+                None
+            }
+        }
+    }
+
+    struct PoweredSender {
+        id: NodeId,
+        sf: u8,
+        frequency: u32,
+        duration_us: u64,
+        tx_power_dbm: i8,
+        fired: bool,
+    }
+
+    impl PoweredSender {
+        fn new(id: u32, sf: u8, frequency: u32, duration_us: u64, tx_power_dbm: i8) -> Self {
+            Self {
+                id: NodeId(id),
+                sf,
+                frequency,
+                duration_us,
+                tx_power_dbm,
+                fired: false,
+            }
+        }
+    }
+
+    impl NodeHandle for PoweredSender {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+            if !self.fired {
+                self.fired = true;
+                Some(make_tx_power(
+                    vec![self.id.0 as u8; 4],
+                    self.sf,
+                    self.frequency,
+                    self.duration_us,
+                    self.tx_power_dbm,
+                ))
+            } else {
+                None
+            }
+        }
+        fn update(&mut self, _time: SimTime) -> Option<SimTime> {
             None
         }
     }
-}
 
-/// A pure receiver node that counts received frames.
-struct Receiver {
-    id: NodeId,
-}
+    struct Receiver {
+        id: NodeId,
+        count: usize,
+    }
 
-impl Receiver {
-    fn new(id: u32) -> Self {
-        Self { id: NodeId(id) }
+    impl Receiver {
+        fn new(id: u32) -> Self {
+            Self {
+                id: NodeId(id),
+                count: 0,
+            }
+        }
     }
-}
 
-impl NodeHandle for Receiver {
-    fn node_id(&self) -> NodeId {
-        self.id
-    }
-    fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
-        None
-    }
-    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
-        None
-    }
-    fn update(&mut self, _time: SimTime) -> Option<SimTime> {
-        None
-    }
-}
-
-/// Traffic model that fires exactly `n` times, one payload per poll.
-///
-/// Note: `NShot` decrements and returns on every call regardless of `time`.
-/// This works correctly in these tests because `AlohaNode` only polls the
-/// traffic model from the `Idle` path — so both payloads cannot be consumed
-/// at the same timestamp.  If the state machine were ever changed to poll
-/// more aggressively, this helper should be replaced with a time-gated
-/// model like `FireOnce` to avoid accidentally consuming both payloads
-/// before the first TX completes.
-struct NShot(u8);
-
-impl TrafficModel for NShot {
-    fn next_payload(&mut self, _time: SimTime) -> Option<Vec<u8>> {
-        if self.0 > 0 {
-            self.0 -= 1;
-            Some(vec![self.0])
-        } else {
+    impl NodeHandle for Receiver {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+            self.count += 1;
+            None
+        }
+        fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+            None
+        }
+        fn update(&mut self, _time: SimTime) -> Option<SimTime> {
             None
         }
     }
-}
 
-/// Wraps an `AlohaNode` and records the simulation time of each TX via a
-/// shared `Rc<RefCell<Vec<SimTime>>>` so callers can inspect timings after
-/// `scheduler.run()` consumes the boxed node.
-struct RecordingNode<T: TrafficModel> {
-    inner: AlohaNode<T>,
-    tx_times: Rc<RefCell<Vec<SimTime>>>,
-}
+    #[test]
+    fn single_sender_all_delivered() {
+        let mut sched = Scheduler::new(20_000_000);
+        let sender = PeriodicSender::new(1, 1_000_000, 50_000, 5, 7, 868_100_000);
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(sender), Some(0));
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 5);
+        assert_eq!(sched.metrics.total_rx, 5);
+        assert_eq!(sched.metrics.total_collisions, 0);
+    }
 
-impl<T: TrafficModel> NodeHandle for RecordingNode<T> {
-    fn node_id(&self) -> NodeId {
-        self.inner.node_id()
+    #[test]
+    fn two_simultaneous_senders_collide() {
+        let mut sched = Scheduler::new(1_000_000);
+        let sender1 = PeriodicSender::new(1, 500_000, 200_000, 1, 7, 868_100_000);
+        let sender2 = PeriodicSender::new(2, 500_000, 200_000, 1, 7, 868_100_000);
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(sender1), Some(0));
+        sched.add_node(Box::new(sender2), Some(0));
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 2);
+        assert!(
+            sched.metrics.total_collisions >= 1,
+            "simultaneous same-SF/freq transmissions should collide"
+        );
     }
-    fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
-        self.inner.on_receive(frame, time)
+
+    #[test]
+    fn different_frequencies_no_collision() {
+        let mut sched = Scheduler::new(1_000_000);
+        let sender1 = PeriodicSender::new(1, 500_000, 200_000, 1, 7, 868_100_000);
+        let sender2 = PeriodicSender::new(2, 500_000, 200_000, 1, 7, 868_300_000);
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(sender1), Some(0));
+        sched.add_node(Box::new(sender2), Some(0));
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 2);
+        assert_eq!(sched.metrics.total_rx, 4);
+        assert_eq!(sched.metrics.total_collisions, 0);
     }
-    fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
-        let tx = self.inner.poll_transmit(time);
-        if tx.is_some() {
-            self.tx_times.borrow_mut().push(time);
+
+    #[test]
+    fn different_sf_no_collision() {
+        let mut sched = Scheduler::new(1_000_000);
+        let sender1 = PeriodicSender::new(1, 500_000, 200_000, 1, 7, 868_100_000);
+        let sender2 = PeriodicSender::new(2, 500_000, 200_000, 1, 12, 868_100_000);
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(sender1), Some(0));
+        sched.add_node(Box::new(sender2), Some(0));
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 2);
+        assert_eq!(sched.metrics.total_rx, 4);
+        assert_eq!(sched.metrics.total_collisions, 0);
+    }
+
+    #[test]
+    fn sequential_transmissions_no_collision() {
+        let mut sched = Scheduler::new(20_000_000);
+        let sender1 = PeriodicSender::new(1, 2_000_000, 200_000, 3, 7, 868_100_000);
+        let sender2 = PeriodicSender::new(2, 2_000_000, 200_000, 3, 7, 868_100_000);
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(sender1), Some(0));
+        sched.add_node(Box::new(sender2), Some(1_000_000));
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 6);
+        assert_eq!(sched.metrics.total_collisions, 0);
+    }
+
+    #[test]
+    fn five_simultaneous_senders_high_collision_rate() {
+        let mut sched = Scheduler::new(1_000_000);
+        for i in 1..=5u32 {
+            let sender = PeriodicSender::new(i, 500_000, 200_000, 1, 7, 868_100_000);
+            sched.add_node(Box::new(sender), Some(0));
         }
-        tx
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 5);
+        assert!(
+            sched.metrics.total_collisions >= 1,
+            "5 simultaneous senders must produce collisions"
+        );
+        assert_eq!(sched.metrics.total_rx, 0);
     }
-    fn update(&mut self, time: SimTime) -> Option<SimTime> {
-        self.inner.update(time)
+
+    #[test]
+    fn capture_effect_recorded_in_metrics() {
+        let mut sched = Scheduler::new(1_000_000);
+        let strong = PoweredSender::new(1, 7, 868_100_000, 200_000, 20);
+        let weak = PoweredSender::new(2, 7, 868_100_000, 200_000, 14);
+        let receiver = Receiver::new(99);
+        sched.add_node(Box::new(strong), Some(0));
+        sched.add_node(Box::new(weak), Some(0));
+        sched.add_node(Box::new(receiver), None);
+        sched.run();
+        assert_eq!(sched.metrics.total_tx, 2);
+        assert_eq!(sched.metrics.total_captures, 1, "expected one capture event");
+        assert_eq!(
+            sched.metrics.total_collisions, 1,
+            "weak sender should be marked collided"
+        );
+        assert_eq!(
+            sched.metrics.total_rx, 2,
+            "captured frame delivered to 2 non-sender nodes (weak sender + receiver)"
+        );
     }
-}
-
-// ---------------------------------------------------------------------------
-// Test 1: single_node_delivery
-// ---------------------------------------------------------------------------
-
-/// One sender fires exactly one packet; the single receiver must receive it.
-#[test]
-fn single_node_delivery() {
-    let sim_end = LORA_SF7_DURATION_US * 10;
-    let mut scheduler = Scheduler::new(sim_end);
-
-    let traffic = FireOnce::new(vec![0xAB], 0);
-    let sender = AlohaNode::new(NodeId(1), traffic, 0, 1);
-    scheduler.add_node(Box::new(sender), Some(0));
-    scheduler.add_node(Box::new(Receiver::new(2)), None);
-
-    scheduler.run();
-
-    assert_eq!(scheduler.metrics.total_tx, 1, "exactly one TX expected");
-    assert_eq!(
-        scheduler.metrics.total_rx, 1,
-        "single packet must be delivered to the receiver"
-    );
-    assert_eq!(
-        scheduler.metrics.total_collisions, 0,
-        "no collision with a single sender"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Test 2: multi_node_collision
-// ---------------------------------------------------------------------------
-
-/// Two senders transmit at the same time on the same SF/frequency; the
-/// channel model must detect the collision (both frames collided, zero
-/// deliveries).
-#[test]
-fn multi_node_collision() {
-    let sim_end = LORA_SF7_DURATION_US * 10;
-    let mut scheduler = Scheduler::new(sim_end);
-
-    // Both nodes fire at t=0 → TX start times coincide exactly.
-    scheduler.add_node(
-        Box::new(AlohaNode::new(
-            NodeId(1),
-            FireOnce::new(vec![0x01], 0),
-            0,
-            10,
-        )),
-        Some(0),
-    );
-    scheduler.add_node(
-        Box::new(AlohaNode::new(
-            NodeId(2),
-            FireOnce::new(vec![0x02], 0),
-            0,
-            20,
-        )),
-        Some(0),
-    );
-    scheduler.add_node(Box::new(Receiver::new(3)), None);
-
-    scheduler.run();
-
-    assert_eq!(scheduler.metrics.total_tx, 2, "both nodes must transmit");
-    // With exactly two simultaneous same-SF/freq transmitters there should be
-    // exactly 2 collision records (one per colliding CompletedTx).
-    assert_eq!(
-        scheduler.metrics.total_collisions, 2,
-        "both concurrent same-SF/freq TXs must collide; got {}",
-        scheduler.metrics.total_collisions
-    );
-    assert_eq!(
-        scheduler.metrics.total_rx, 0,
-        "no frame must be delivered when both collide"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Test 3: backoff_retransmission
-// ---------------------------------------------------------------------------
-
-/// A node with two queued payloads and a non-zero backoff window must place
-/// its second TX strictly after the first TX, and that gap must be at least
-/// the on-air duration of the first packet.
-#[test]
-fn backoff_retransmission() {
-    // Backoff window: up to 200 ms.
-    let backoff_range_us = 200_000u64;
-    // Give enough time for 2 TXs + max backoff.
-    let sim_end = LORA_SF7_DURATION_US * 2 + backoff_range_us + 100_000;
-
-    let tx_times: Rc<RefCell<Vec<SimTime>>> = Rc::new(RefCell::new(Vec::new()));
-    let tx_times_out = Rc::clone(&tx_times);
-
-    let mut scheduler = Scheduler::new(sim_end);
-    scheduler.add_node(
-        Box::new(RecordingNode {
-            inner: AlohaNode::new(NodeId(1), NShot(2), backoff_range_us, 42),
-            tx_times,
-        }),
-        Some(0),
-    );
-    scheduler.add_node(Box::new(Receiver::new(2)), None);
-    scheduler.run();
-
-    let times = tx_times_out.borrow();
-    assert_eq!(
-        times.len(),
-        2,
-        "two-shot traffic must produce exactly two TXs; got {}",
-        times.len()
-    );
-    assert!(
-        times[1] > times[0],
-        "second TX ({}) must happen after first TX ({})",
-        times[1],
-        times[0]
-    );
-    // The minimum gap between the two TXs is LORA_SF7_DURATION_US because:
-    //   - after poll_transmit fires, the node enters AwaitingBackoffStart
-    //   - the next update() call computes:
-    //       until = tx_start + LORA_SF7_DURATION_US + drawn_backoff
-    //   - drawn_backoff >= 0, so the gap is always >= LORA_SF7_DURATION_US
-    // This covers the full on-air time of the first packet even when the
-    // drawn backoff is zero.
-    assert!(
-        times[1] >= times[0] + LORA_SF7_DURATION_US,
-        "second TX must be at least one TX-duration after the first; \
-         first={} second={} duration={}",
-        times[0],
-        times[1],
-        LORA_SF7_DURATION_US
-    );
-
-    // Sanity: total_tx matches.
-    assert_eq!(scheduler.metrics.total_tx, 2);
 }

--- a/tests/aloha.rs
+++ b/tests/aloha.rs
@@ -8,7 +8,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use theatron::aloha::{AlohaNode, PoissonTraffic, LORA_SF7_DURATION_US};
+use theatron::aloha::{AlohaNode, UniformInterarrivalTraffic, LORA_SF7_DURATION_US};
 use theatron::scheduler::{NodeHandle, Scheduler};
 use theatron::time::SimTime;
 use theatron::traits::TrafficModel;
@@ -73,6 +73,14 @@ impl NodeHandle for Receiver {
 }
 
 /// Traffic model that fires exactly `n` times, one payload per poll.
+///
+/// Note: `NShot` decrements and returns on every call regardless of `time`.
+/// This works correctly in these tests because `AlohaNode` only polls the
+/// traffic model from the `Idle` path — so both payloads cannot be consumed
+/// at the same timestamp.  If the state machine were ever changed to poll
+/// more aggressively, this helper should be replaced with a time-gated
+/// model like `FireOnce` to avoid accidentally consuming both payloads
+/// before the first TX completes.
 struct NShot(u8);
 
 impl TrafficModel for NShot {
@@ -177,8 +185,10 @@ fn multi_node_collision() {
     scheduler.run();
 
     assert_eq!(scheduler.metrics.total_tx, 2, "both nodes must transmit");
-    assert!(
-        scheduler.metrics.total_collisions >= 2,
+    // With exactly two simultaneous same-SF/freq transmitters there should be
+    // exactly 2 collision records (one per colliding CompletedTx).
+    assert_eq!(
+        scheduler.metrics.total_collisions, 2,
         "both concurrent same-SF/freq TXs must collide; got {}",
         scheduler.metrics.total_collisions
     );
@@ -229,8 +239,13 @@ fn backoff_retransmission() {
         times[1],
         times[0]
     );
-    // The node cannot re-transmit until after the first packet has been on
-    // air (TX duration) plus any backoff time (≥ 0).
+    // The minimum gap between the two TXs is LORA_SF7_DURATION_US because:
+    //   - after poll_transmit fires, the node enters AwaitingBackoffStart
+    //   - the next update() call computes:
+    //       until = tx_start + LORA_SF7_DURATION_US + drawn_backoff
+    //   - drawn_backoff >= 0, so the gap is always >= LORA_SF7_DURATION_US
+    // This covers the full on-air time of the first packet even when the
+    // drawn backoff is zero.
     assert!(
         times[1] >= times[0] + LORA_SF7_DURATION_US,
         "second TX must be at least one TX-duration after the first; \

--- a/tests/core_coverage.rs
+++ b/tests/core_coverage.rs
@@ -1,0 +1,573 @@
+//! Integration tests covering undertested core components.
+//!
+//! These complement the existing unit tests and integration tests by targeting
+//! gaps identified through coverage analysis: channel edge cases, scheduler
+//! ordering invariants, metrics isolation, and time conversion edge cases.
+
+use theatron::channel::Channel;
+use theatron::metrics::MetricsCollector;
+use theatron::scheduler::{NodeHandle, Scheduler};
+use theatron::time::{SimTime, ms_to_sim_time, sim_time_to_ms};
+use theatron::traits::InterferenceSource;
+use theatron::types::{ChannelEvent, NodeId, RxMetadata, Transmission};
+
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tx(sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
+    Transmission {
+        payload: vec![0xAA],
+        sf,
+        bandwidth: 125_000,
+        coding_rate: 5,
+        frequency: freq,
+        duration_us: dur,
+        tx_power_dbm: power,
+    }
+}
+
+fn tx_with_payload(payload: Vec<u8>, sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
+    Transmission {
+        payload,
+        sf,
+        bandwidth: 125_000,
+        coding_rate: 5,
+        frequency: freq,
+        duration_us: dur,
+        tx_power_dbm: power,
+    }
+}
+
+struct TestNode {
+    id: NodeId,
+    pending_tx: Option<Transmission>,
+    received: Vec<RxMetadata>,
+    wake_schedule: Vec<SimTime>,
+    wake_idx: usize,
+}
+
+impl TestNode {
+    fn new(id: u32) -> Self {
+        Self {
+            id: NodeId(id),
+            pending_tx: None,
+            received: Vec::new(),
+            wake_schedule: Vec::new(),
+            wake_idx: 0,
+        }
+    }
+
+    fn with_tx(mut self, t: Transmission) -> Self {
+        self.pending_tx = Some(t);
+        self
+    }
+
+    fn with_wakes(mut self, wakes: Vec<SimTime>) -> Self {
+        self.wake_schedule = wakes;
+        self
+    }
+}
+
+impl NodeHandle for TestNode {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+
+    fn on_receive(&mut self, frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+        self.received.push(frame);
+        None
+    }
+
+    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+        self.pending_tx.take()
+    }
+
+    fn update(&mut self, _time: SimTime) -> Option<SimTime> {
+        if self.wake_idx < self.wake_schedule.len() {
+            let t = self.wake_schedule[self.wake_idx];
+            self.wake_idx += 1;
+            Some(t)
+        } else {
+            None
+        }
+    }
+}
+
+/// Node that replies with a transmission upon receiving a frame.
+struct EchoNode {
+    id: NodeId,
+    reply: Option<Transmission>,
+    received: Vec<RxMetadata>,
+}
+
+impl EchoNode {
+    fn new(id: u32, reply: Transmission) -> Self {
+        Self {
+            id: NodeId(id),
+            reply: Some(reply),
+            received: Vec::new(),
+        }
+    }
+}
+
+impl NodeHandle for EchoNode {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+    fn on_receive(&mut self, frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+        self.received.push(frame);
+        None
+    }
+    /// Replies exactly once, on the first poll after the first receive.
+    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+        if !self.received.is_empty() {
+            self.reply.take()
+        } else {
+            None
+        }
+    }
+    fn update(&mut self, _time: SimTime) -> Option<SimTime> {
+        None
+    }
+}
+
+struct CountingInterferer {
+    tx: Transmission,
+    remaining: usize,
+    interval: u64,
+}
+
+impl InterferenceSource for CountingInterferer {
+    fn observe(&mut self, _event: &ChannelEvent, _time: SimTime) {}
+    fn poll_inject(&mut self, _time: SimTime) -> Option<Transmission> {
+        if self.remaining > 0 {
+            self.remaining -= 1;
+            Some(self.tx.clone())
+        } else {
+            None
+        }
+    }
+    fn next_poll_time(&self, current_time: SimTime) -> Option<SimTime> {
+        if self.remaining > 0 {
+            Some(current_time + self.interval)
+        } else {
+            None
+        }
+    }
+}
+
+// ===========================================================================
+// Channel edge cases
+// ===========================================================================
+
+#[test]
+fn channel_empty_resolve_returns_nothing() {
+    let mut ch = Channel::new();
+    let events = ch.resolve_at(1_000_000);
+    assert!(events.is_empty());
+}
+
+#[test]
+fn channel_empty_drain_returns_nothing() {
+    let mut ch = Channel::new();
+    assert!(ch.drain_completed().is_empty());
+}
+
+#[test]
+fn channel_resolve_partial_only_finished() {
+    let mut ch = Channel::new();
+    // TX1 ends at 50_000, TX2 ends at 150_000
+    ch.begin_transmission(NodeId(1), &tx(7, 868_100_000, 50_000, 14), 0);
+    ch.begin_transmission(NodeId(2), &tx(8, 868_100_000, 150_000, 14), 0);
+
+    let events = ch.resolve_at(60_000);
+    // Only TX1 should have completed
+    assert_eq!(events.len(), 1);
+    let completed = ch.drain_completed();
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].0, NodeId(1));
+}
+
+#[test]
+fn channel_compute_rssi_and_snr_with_default_path_loss() {
+    // Coupling: Channel::new() uses path_loss_db=100.0 and noise_floor_dbm=-117.0.
+    // Expected values are derived from those defaults:
+    //   rssi = tx_power_dbm - path_loss_db = 14 - 100 = -86.0
+    //   snr  = rssi - noise_floor_dbm      = -86 - (-117) = 31.0
+    let ch = Channel::new();
+    let expected_rssi = 14.0_f32 - 100.0; // tx_power - path_loss_db
+    let expected_snr = expected_rssi - (-117.0_f32); // rssi - noise_floor_dbm
+    let rssi = ch.compute_rssi(14);
+    assert!((rssi - expected_rssi).abs() < 0.001);
+    let snr = ch.compute_snr(rssi);
+    assert!((snr - expected_snr).abs() < 0.001);
+}
+
+#[test]
+fn channel_compute_rssi_negative_power() {
+    let ch = Channel::new();
+    let rssi = ch.compute_rssi(-10);
+    assert!((rssi - (-110.0)).abs() < 0.001);
+}
+
+#[test]
+fn channel_resolve_filters_by_time() {
+    let mut ch = Channel::new();
+    // TX1 ends at 50_000, TX2 ends at 150_000
+    ch.begin_transmission(NodeId(1), &tx(7, 868_100_000, 50_000, 14), 0);
+    ch.begin_transmission(NodeId(2), &tx(8, 868_100_000, 150_000, 14), 0);
+    ch.resolve_at(60_000);
+
+    // drain_completed at this point only includes TX1 (only it was resolved)
+    let completed_partial = ch.drain_completed();
+    assert_eq!(completed_partial.len(), 1);
+    assert_eq!(completed_partial[0].0, NodeId(1));
+
+    // Resolve TX2 and confirm it drains correctly
+    ch.resolve_at(200_000);
+    let completed_rest = ch.drain_completed();
+    assert_eq!(completed_rest.len(), 1);
+    assert_eq!(completed_rest[0].0, NodeId(2));
+}
+
+#[test]
+fn channel_late_strong_captures_earlier_weak() {
+    // Weak signal starts first, then a strong signal arrives and captures it.
+    // resolve_at uses end <= time (inclusive), so both TXs resolve at t=80_000:
+    //   weak TX: start=0, dur=80_000 -> ends at 80_000 (included)
+    //   strong TX: start=10_000, dur=60_000 -> ends at 70_000 (included)
+    let mut ch = Channel::new();
+    let weak = tx(7, 868_100_000, 80_000, 8);
+    let strong = tx(7, 868_100_000, 60_000, 20);
+    ch.begin_transmission(NodeId(1), &weak, 0);
+    ch.begin_transmission(NodeId(2), &strong, 10_000);
+    ch.resolve_at(80_000);
+    let completed = ch.drain_completed();
+
+    let strong_entry = completed
+        .iter()
+        .find(|(id, _, _, _)| *id == NodeId(2))
+        .unwrap();
+    let weak_entry = completed
+        .iter()
+        .find(|(id, _, _, _)| *id == NodeId(1))
+        .unwrap();
+    assert!(!strong_entry.1, "strong signal should not be collided");
+    assert!(strong_entry.2, "strong signal should be captured");
+    assert!(weak_entry.1, "weak signal should be collided");
+}
+
+#[test]
+fn channel_begin_transmission_returns_started_event() {
+    let mut ch = Channel::new();
+    let event = ch.begin_transmission(NodeId(42), &tx(7, 868_100_000, 50_000, 14), 1_000);
+    match event {
+        ChannelEvent::TransmissionStarted {
+            sender,
+            sf,
+            frequency,
+            time,
+        } => {
+            assert_eq!(sender, NodeId(42));
+            assert_eq!(sf, 7);
+            assert_eq!(frequency, 868_100_000);
+            assert_eq!(time, 1_000);
+        }
+        _ => panic!("expected TransmissionStarted"),
+    }
+}
+
+#[test]
+fn channel_resolve_returns_completed_events() {
+    let mut ch = Channel::new();
+    ch.begin_transmission(NodeId(1), &tx(7, 868_100_000, 50_000, 14), 0);
+    let events = ch.resolve_at(50_000);
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ChannelEvent::TransmissionCompleted {
+            sender,
+            collided,
+            time,
+        } => {
+            assert_eq!(*sender, NodeId(1));
+            assert!(!collided);
+            assert_eq!(*time, 50_000);
+        }
+        _ => panic!("expected TransmissionCompleted"),
+    }
+}
+
+#[test]
+fn channel_multiple_resolve_cycles() {
+    let mut ch = Channel::new();
+    ch.begin_transmission(NodeId(1), &tx(7, 868_100_000, 50_000, 14), 0);
+    ch.resolve_at(50_000);
+    ch.drain_completed();
+
+    ch.begin_transmission(NodeId(2), &tx(7, 868_100_000, 30_000, 14), 100_000);
+    ch.resolve_at(130_000);
+    let completed = ch.drain_completed();
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].0, NodeId(2));
+}
+
+// ===========================================================================
+// Channel proptest
+// ===========================================================================
+
+proptest! {
+    #[test]
+    fn capture_is_asymmetric(
+        strong_power in 14i8..=22,
+        weak_power in -10i8..=8,
+    ) {
+        prop_assume!(strong_power as f32 - weak_power as f32 >= 6.0);
+        let mut ch = Channel::new();
+        ch.begin_transmission(NodeId(1), &tx(7, 868_100_000, 50_000, strong_power), 0);
+        ch.begin_transmission(NodeId(2), &tx(7, 868_100_000, 50_000, weak_power), 10_000);
+        ch.resolve_at(60_000);
+        let completed = ch.drain_completed();
+        // Strong signal (NodeId(1)) should survive; weak signal (NodeId(2)) should not.
+        let survivors: Vec<_> = completed.iter().filter(|(_, collided, _, _)| !collided).collect();
+        prop_assert_eq!(survivors.len(), 1);
+        // Verify the survivor is the strong sender by both NodeId and RSSI.
+        prop_assert_eq!(survivors[0].0, NodeId(1));
+        prop_assert_eq!(survivors[0].3.rssi, ch.compute_rssi(strong_power));
+    }
+
+    #[test]
+    fn resolve_at_before_end_returns_nothing(start in 0u64..1_000_000, dur in 2u64..1_000_000) {
+        let mut ch = Channel::new();
+        ch.begin_transmission(NodeId(1), &tx(7, 868_100_000, dur, 14), start);
+        // Resolve at the midpoint, which is strictly before the transmission ends.
+        // dur >= 2 ensures dur/2 >= 1, so midpoint is always strictly less than start+dur.
+        let midpoint = start + dur / 2;
+        let events = ch.resolve_at(midpoint);
+        prop_assert!(events.is_empty());
+    }
+}
+
+// ===========================================================================
+// Scheduler invariants
+// ===========================================================================
+
+#[test]
+fn scheduler_current_time_progresses() {
+    let mut sched = Scheduler::new(500_000);
+    let node = TestNode::new(1).with_wakes(vec![100_000, 200_000, 300_000]);
+    sched.add_node(Box::new(node), Some(0));
+    sched.run();
+    // current_time should be at least 300_000 (last scheduled wake)
+    assert!(sched.current_time() >= 300_000);
+}
+
+#[test]
+fn scheduler_events_beyond_end_time_are_skipped() {
+    let mut sched = Scheduler::new(100_000);
+    // Node schedules a wake at 200_000 which is beyond end_time
+    let node = TestNode::new(1).with_wakes(vec![200_000]);
+    sched.add_node(Box::new(node), Some(0));
+    sched.run();
+    assert!(sched.current_time() <= 100_000);
+}
+
+#[test]
+fn scheduler_determinism() {
+    fn run_scenario() -> (u64, u64, u64, u64) {
+        let mut sched = Scheduler::new(500_000);
+        let mut s1 = TestNode::new(1);
+        s1.pending_tx = Some(tx(7, 868_100_000, 50_000, 14));
+        let mut s2 = TestNode::new(2);
+        s2.pending_tx = Some(tx(7, 868_100_000, 50_000, 14));
+        sched.add_node(Box::new(s1), Some(0));
+        sched.add_node(Box::new(s2), Some(10_000));
+        sched.add_node(Box::new(TestNode::new(3)), None);
+        sched.run();
+        (
+            sched.metrics.total_tx,
+            sched.metrics.total_rx,
+            sched.metrics.total_collisions,
+            sched.current_time(),
+        )
+    }
+    assert_eq!(run_scenario(), run_scenario());
+}
+
+#[test]
+fn scheduler_multi_hop_reply_chain() {
+    // A sends to B, B echoes back, A receives the reply
+    let mut sched = Scheduler::new(500_000);
+    let sender = TestNode::new(1).with_tx(tx_with_payload(vec![0x01], 7, 868_100_000, 30_000, 14));
+    let echo = EchoNode::new(2, tx_with_payload(vec![0x02], 7, 868_100_000, 30_000, 14));
+    sched.add_node(Box::new(sender), Some(0));
+    sched.add_node(Box::new(echo), None);
+    sched.run();
+
+    assert_eq!(sched.metrics.total_tx, 2, "original + reply");
+    assert_eq!(
+        sched.metrics.total_rx, 2,
+        "each node receives the other's TX"
+    );
+}
+
+#[test]
+fn scheduler_two_interferers_simultaneously() {
+    let mut sched = Scheduler::new(300_000);
+    sched.add_node(Box::new(TestNode::new(1)), None);
+
+    let i1 = CountingInterferer {
+        tx: tx(7, 868_100_000, 30_000, 14),
+        remaining: 2,
+        interval: 100_000,
+    };
+    let i2 = CountingInterferer {
+        tx: tx(8, 868_300_000, 20_000, 10),
+        remaining: 3,
+        interval: 80_000,
+    };
+    sched.add_interferer(Box::new(i1), 0);
+    sched.add_interferer(Box::new(i2), 0);
+    sched.run();
+
+    // Total airtime = 2*30_000 + 3*20_000 = 120_000
+    assert_eq!(sched.metrics.total_airtime_us, 120_000);
+}
+
+#[test]
+fn scheduler_interferer_and_node_different_sf_no_collision() {
+    let mut sched = Scheduler::new(200_000);
+    let mut node = TestNode::new(1);
+    node.pending_tx = Some(tx(7, 868_100_000, 50_000, 14));
+    sched.add_node(Box::new(node), Some(0));
+    sched.add_node(Box::new(TestNode::new(2)), None);
+
+    // Interferer on different SF
+    let interferer = CountingInterferer {
+        tx: tx(12, 868_100_000, 50_000, 14),
+        remaining: 1,
+        interval: 0,
+    };
+    sched.add_interferer(Box::new(interferer), 10_000);
+    sched.run();
+
+    assert_eq!(sched.metrics.total_collisions, 0);
+    // Node 1 TX (SF7) -> delivered to Node 2 (1 RX)
+    // Interferer TX (SF12) -> delivered to Node 1 and Node 2 (2 RX)
+    // Total: 3 RX
+    assert_eq!(
+        sched.metrics.total_rx, 3,
+        "node TX + interferer TX delivered on different SFs"
+    );
+}
+
+#[test]
+fn scheduler_no_nodes_no_events_finishes_immediately() {
+    let mut sched = Scheduler::new(1_000_000);
+    sched.run();
+    assert_eq!(sched.current_time(), 0);
+    assert_eq!(sched.metrics.total_tx, 0);
+}
+
+#[test]
+fn scheduler_node_tx_count_per_node() {
+    let mut sched = Scheduler::new(500_000);
+    let mut n1 = TestNode::new(1);
+    n1.pending_tx = Some(tx(7, 868_100_000, 30_000, 14));
+    sched.add_node(Box::new(n1), Some(0));
+    sched.add_node(Box::new(TestNode::new(2)), None);
+    sched.run();
+
+    assert_eq!(sched.metrics.node_tx_count(NodeId(1)), 1);
+    assert_eq!(sched.metrics.node_tx_count(NodeId(2)), 0);
+    assert_eq!(sched.metrics.node_rx_count(NodeId(2)), 1);
+    assert_eq!(sched.metrics.node_rx_count(NodeId(1)), 0);
+}
+
+// ===========================================================================
+// Scheduler proptest
+// ===========================================================================
+
+proptest! {
+    #[test]
+    fn scheduler_airtime_equals_sum_of_durations(
+        dur1 in 10_000u64..100_000,
+        dur2 in 10_000u64..100_000,
+    ) {
+        // The two TXs use different SFs (7 and 8), so they are orthogonal and
+        // cannot collide regardless of timing overlap. Non-collision here is due
+        // to different-SF isolation, not non-overlapping airtime windows.
+        let mut sched = Scheduler::new(1_000_000);
+        let mut n1 = TestNode::new(1);
+        n1.pending_tx = Some(tx(7, 868_100_000, dur1, 14));
+        let mut n2 = TestNode::new(2);
+        n2.pending_tx = Some(tx(8, 868_100_000, dur2, 14));
+        sched.add_node(Box::new(n1), Some(0));
+        sched.add_node(Box::new(n2), Some(0));
+        sched.run();
+        prop_assert_eq!(sched.metrics.total_collisions, 0);
+        prop_assert_eq!(sched.metrics.total_airtime_us, dur1 + dur2);
+    }
+}
+
+// ===========================================================================
+// Metrics isolation
+// ===========================================================================
+
+#[test]
+fn metrics_per_node_counters_are_independent() {
+    let mut m = MetricsCollector::new();
+    m.record_tx(NodeId(1));
+    m.record_tx(NodeId(1));
+    m.record_tx(NodeId(2));
+    m.record_rx(NodeId(3));
+    m.record_rx(NodeId(3));
+    m.record_rx(NodeId(3));
+
+    assert_eq!(m.node_tx_count(NodeId(1)), 2);
+    assert_eq!(m.node_tx_count(NodeId(2)), 1);
+    assert_eq!(m.node_tx_count(NodeId(3)), 0);
+    assert_eq!(m.node_rx_count(NodeId(1)), 0);
+    assert_eq!(m.node_rx_count(NodeId(3)), 3);
+    assert_eq!(m.total_tx, 3);
+    assert_eq!(m.total_rx, 3);
+}
+
+#[test]
+fn metrics_default_is_same_as_new() {
+    let m1 = MetricsCollector::new();
+    let m2 = MetricsCollector::default();
+    assert_eq!(m1.total_tx, m2.total_tx);
+    assert_eq!(m1.total_rx, m2.total_rx);
+    assert_eq!(m1.total_collisions, m2.total_collisions);
+    assert_eq!(m1.total_captures, m2.total_captures);
+    assert_eq!(m1.total_airtime_us, m2.total_airtime_us);
+}
+
+// ===========================================================================
+// Time conversion edge cases
+// ===========================================================================
+
+#[test]
+fn sim_time_to_ms_truncates_sub_millisecond() {
+    // 1_500 us = 1.5 ms, should truncate to 1
+    assert_eq!(sim_time_to_ms(1_500), 1);
+    assert_eq!(sim_time_to_ms(999), 0);
+    assert_eq!(sim_time_to_ms(1_999), 1);
+}
+
+#[test]
+fn ms_to_sim_time_max_u32() {
+    let result = ms_to_sim_time(u32::MAX);
+    assert_eq!(result, u32::MAX as u64 * 1_000);
+}
+
+proptest! {
+    #[test]
+    fn sim_time_to_ms_never_exceeds_input(us in 0u64..u64::MAX / 2) {
+        let ms = sim_time_to_ms(us);
+        prop_assert!(ms * 1_000 <= us);
+    }
+}

--- a/tests/lorawan_frame_correctness.rs
+++ b/tests/lorawan_frame_correctness.rs
@@ -4,41 +4,8 @@ use lorawan::parser::{DataHeader, DataPayload, MHDRAble, MType, PhyPayload};
 use lorawan_device::nb_device::radio::{Event, PhyRxTx, Response, RfConfig, RxQuality, TxConfig};
 use lorawan_device::nb_device::{Device, Event as DevEvent};
 use lorawan_device::{AppSKey, DevAddr, JoinMode, NewSKey, Timings};
-use rand_core::{Error, RngCore, impls};
-
+use theatron::prng::Xorshift64;
 use theatron::types::Transmission;
-
-struct Xorshift64(u64);
-
-impl Xorshift64 {
-    fn new(seed: u64) -> Self {
-        Self(if seed == 0 { 1 } else { seed })
-    }
-}
-
-impl RngCore for Xorshift64 {
-    fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        let mut x = self.0;
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        self.0 = x;
-        x
-    }
-
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_next(self, dest);
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
-}
 
 #[derive(Debug)]
 struct MinimalRadio {

--- a/tests/protocol_contract.rs
+++ b/tests/protocol_contract.rs
@@ -1,0 +1,100 @@
+//! Contract tests for the Protocol trait.
+//!
+//! These tests verify that a conforming implementation satisfies the
+//! behavioural expectations of the trait: init returns a wake time,
+//! poll_transmit drains after the first call, and on_receive is safe
+//! to call at any time.
+
+use theatron::traits::Protocol;
+use theatron::types::{RxMetadata, Transmission};
+
+/// The simplest possible Protocol implementation: transmits one fixed
+/// frame on the first poll, then goes silent.
+struct MinimalProtocol;
+
+/// Internal state: tracks whether the single transmission has been sent.
+struct MinimalState {
+    transmitted: bool,
+}
+
+impl Protocol for MinimalProtocol {
+    type Config = ();
+    type State = MinimalState;
+    type Metrics = ();
+
+    fn init(&self, _config: ()) -> (MinimalState, Option<u64>) {
+        (MinimalState { transmitted: false }, Some(0))
+    }
+
+    fn on_receive(&self, _state: &mut MinimalState, _frame: RxMetadata, _time: u64) -> Option<u64> {
+        None
+    }
+
+    fn poll_transmit(&self, state: &mut MinimalState, _time: u64) -> Option<Transmission> {
+        if state.transmitted {
+            return None;
+        }
+        state.transmitted = true;
+        Some(Transmission {
+            payload: vec![0x01],
+            sf: 7,
+            bandwidth: 125_000,
+            coding_rate: 5,
+            frequency: 868_100_000,
+            duration_us: 50_000,
+            tx_power_dbm: 14,
+        })
+    }
+
+    fn update(&self, _state: &mut MinimalState, _time: u64) -> Option<u64> {
+        None
+    }
+
+    fn metrics(&self, _state: &MinimalState) {}
+}
+
+#[test]
+fn protocol_init_provides_wake_time() {
+    let protocol = MinimalProtocol;
+    let (_state, wake_time) = protocol.init(());
+    assert!(
+        wake_time.is_some(),
+        "init() should return Some(wake_time) for a protocol that plans to transmit"
+    );
+}
+
+#[test]
+fn protocol_poll_transmit_once_then_none() {
+    let protocol = MinimalProtocol;
+    let (mut state, _) = protocol.init(());
+
+    let first = protocol.poll_transmit(&mut state, 0);
+    assert!(
+        first.is_some(),
+        "poll_transmit() should return Some(Transmission) on the first call"
+    );
+
+    let second = protocol.poll_transmit(&mut state, 1);
+    assert!(
+        second.is_none(),
+        "poll_transmit() should return None once the single transmission has been sent"
+    );
+}
+
+#[test]
+fn protocol_on_receive_does_not_panic() {
+    let protocol = MinimalProtocol;
+    let (mut state, _) = protocol.init(());
+
+    let frame = RxMetadata {
+        payload: vec![0xAB, 0xCD],
+        rssi: -90.0,
+        snr: 5.0,
+        sf: 7,
+        frequency: 868_100_000,
+        time: 100,
+    };
+
+    // Must not panic.
+    let _ = protocol.on_receive(&mut state, frame, 100);
+}

--- a/tests/protocol_timer_contract.rs
+++ b/tests/protocol_timer_contract.rs
@@ -1,0 +1,322 @@
+//! Tests for the `Protocol` trait contract and the scheduler's timer-delivery invariant.
+//!
+//! # Timer contract
+//!
+//! When `Protocol::update` (or `NodeHandle::update`) returns `Some(t)`, the scheduler
+//! must call `update` again at *exactly* time `t` — no earlier, no later. These tests
+//! verify that invariant holds end-to-end through [`Scheduler::run`].
+//!
+//! The `Protocol` trait is the central abstraction (see [`ARCHITECTURE.md`](../ARCHITECTURE.md));
+//! any regression in the scheduler's wake-scheduling path could silently break every
+//! protocol implementation.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use theatron::scheduler::{NodeHandle, Scheduler};
+use theatron::time::SimTime;
+use theatron::traits::Protocol;
+use theatron::types::{NodeId, RxMetadata, Transmission};
+
+// ---------------------------------------------------------------------------
+// ProtocolNode — bridges Protocol + State into NodeHandle
+// ---------------------------------------------------------------------------
+
+/// Wraps a `Protocol` implementation together with its mutable `State` so the
+/// pair can be registered with `Scheduler` as a `NodeHandle`. This is the
+/// idiomatic glue layer between the stateless `Protocol` trait and the
+/// stateful `NodeHandle` the scheduler drives.
+struct ProtocolNode<P: Protocol> {
+    id: NodeId,
+    protocol: P,
+    state: P::State,
+}
+
+impl<P: Protocol> ProtocolNode<P> {
+    /// Construct a new node, calling `Protocol::init` to obtain the initial state.
+    /// Returns `(Self, initial_wake)` so the caller can pass `initial_wake` to
+    /// [`Scheduler::add_node`].
+    fn new(id: NodeId, protocol: P, config: P::Config) -> (Self, Option<SimTime>) {
+        let (state, wake) = protocol.init(config);
+        (
+            Self {
+                id,
+                protocol,
+                state,
+            },
+            wake,
+        )
+    }
+}
+
+impl<P: Protocol + 'static> NodeHandle for ProtocolNode<P>
+where
+    P::State: 'static,
+{
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+
+    fn on_receive(&mut self, frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+        self.protocol.on_receive(&mut self.state, frame, time)
+    }
+
+    fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+        self.protocol.poll_transmit(&mut self.state, time)
+    }
+
+    fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        self.protocol.update(&mut self.state, time)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The scheduler must call `update` at the *exact* time returned by a previous
+/// `update`. Verified here with a two-phase `Protocol` whose state lives in an
+/// `Rc<RefCell<_>>` so the test can inspect it after `Scheduler::run` returns.
+#[test]
+fn scheduler_delivers_wake_at_exact_scheduled_time() {
+    const RX_WINDOW: SimTime = 1_000_000;
+
+    struct ObservingState {
+        rx_window_fired: bool,
+        rx_window_time: Option<SimTime>,
+        transmit_count: u32,
+    }
+
+    struct ObservingProtocol {
+        shared: Rc<RefCell<ObservingState>>,
+    }
+
+    impl Protocol for ObservingProtocol {
+        type Config = ();
+        type State = (); // state lives in the Rc
+        type Metrics = ();
+
+        fn init(&self, _: ()) -> ((), Option<SimTime>) {
+            ((), Some(0))
+        }
+
+        fn on_receive(&self, _: &mut (), _: RxMetadata, _: SimTime) -> Option<SimTime> {
+            None
+        }
+
+        fn poll_transmit(&self, _: &mut (), _: SimTime) -> Option<Transmission> {
+            let mut s = self.shared.borrow_mut();
+            if s.transmit_count == 0 {
+                s.transmit_count += 1;
+                Some(Transmission {
+                    payload: vec![0xBE, 0xAC, 0x04],
+                    sf: 7,
+                    bandwidth: 125_000,
+                    coding_rate: 5,
+                    frequency: 868_100_000,
+                    duration_us: 50_000,
+                    tx_power_dbm: 14,
+                })
+            } else {
+                None
+            }
+        }
+
+        fn update(&self, _: &mut (), time: SimTime) -> Option<SimTime> {
+            let mut s = self.shared.borrow_mut();
+            if !s.rx_window_fired {
+                s.rx_window_fired = true;
+                Some(RX_WINDOW)
+            } else {
+                s.rx_window_time = Some(time);
+                None
+            }
+        }
+
+        fn metrics(&self, _: &()) {}
+    }
+
+    let shared = Rc::new(RefCell::new(ObservingState {
+        rx_window_fired: false,
+        rx_window_time: None,
+        transmit_count: 0,
+    }));
+
+    let protocol = ObservingProtocol {
+        shared: Rc::clone(&shared),
+    };
+    let (node, initial_wake) = ProtocolNode::new(NodeId(1), protocol, ());
+
+    let mut sched = Scheduler::new(2_000_000);
+    sched.add_node(Box::new(node), initial_wake);
+    sched.run();
+
+    // Timer contract: the scheduler must have advanced to at least RX_WINDOW.
+    assert!(
+        sched.current_time() >= RX_WINDOW,
+        "scheduler did not advance to the scheduled wake time: got {}, expected >= {}",
+        sched.current_time(),
+        RX_WINDOW,
+    );
+
+    // Timer contract: update must have been called at exactly RX_WINDOW.
+    let observed_time = shared.borrow().rx_window_time;
+    assert_eq!(
+        observed_time,
+        Some(RX_WINDOW),
+        "update was not called at the exact scheduled time: got {:?}, expected Some({})",
+        observed_time,
+        RX_WINDOW,
+    );
+
+    assert_eq!(
+        sched.metrics.total_tx, 1,
+        "expected exactly 1 transmission, got {}",
+        sched.metrics.total_tx,
+    );
+}
+
+/// Smoke-test the `ProtocolNode` bridge: a `Protocol` that never transmits and
+/// never requests a wake-up runs to completion without panicking, with zero
+/// transmissions recorded.
+#[test]
+fn protocol_node_no_op_does_not_panic() {
+    struct NoOpProtocol;
+
+    impl Protocol for NoOpProtocol {
+        type Config = ();
+        type State = ();
+        type Metrics = ();
+
+        fn init(&self, _: ()) -> ((), Option<SimTime>) {
+            ((), None)
+        }
+        fn on_receive(&self, _: &mut (), _: RxMetadata, _: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&self, _: &mut (), _: SimTime) -> Option<Transmission> {
+            None
+        }
+        fn update(&self, _: &mut (), _: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn metrics(&self, _: &()) {}
+    }
+
+    let (node, initial_wake) = ProtocolNode::new(NodeId(2), NoOpProtocol, ());
+    let mut sched = Scheduler::new(1_000_000);
+    sched.add_node(Box::new(node), initial_wake);
+    sched.run();
+
+    assert_eq!(sched.metrics.total_tx, 0);
+}
+
+/// A `Protocol` whose `init` returns `Some(0)` must have `update` called at t = 0.
+#[test]
+fn protocol_init_wake_at_zero_fires_update() {
+    let update_called = Rc::new(RefCell::new(false));
+
+    struct WakeAtZeroProtocol {
+        flag: Rc<RefCell<bool>>,
+    }
+
+    impl Protocol for WakeAtZeroProtocol {
+        type Config = ();
+        type State = ();
+        type Metrics = ();
+
+        fn init(&self, _: ()) -> ((), Option<SimTime>) {
+            ((), Some(0))
+        }
+        fn on_receive(&self, _: &mut (), _: RxMetadata, _: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&self, _: &mut (), _: SimTime) -> Option<Transmission> {
+            None
+        }
+        fn update(&self, _: &mut (), _time: SimTime) -> Option<SimTime> {
+            *self.flag.borrow_mut() = true;
+            None
+        }
+        fn metrics(&self, _: &()) {}
+    }
+
+    let (node, initial_wake) = ProtocolNode::new(
+        NodeId(3),
+        WakeAtZeroProtocol {
+            flag: Rc::clone(&update_called),
+        },
+        (),
+    );
+
+    let mut sched = Scheduler::new(1_000_000);
+    sched.add_node(Box::new(node), initial_wake);
+    sched.run();
+
+    assert!(
+        *update_called.borrow(),
+        "update was never called even though init returned Some(0)"
+    );
+}
+
+/// Events scheduled at the same `SimTime` must fire in the order they were
+/// scheduled (FIFO via the scheduler's internal seq counter). Without this
+/// invariant, simulations are non-deterministic when multiple nodes wake at
+/// the same instant.
+///
+/// Setup: three nodes each request a wake at t = 50_000 (registered in order
+/// 1, 2, 3). Each node records the *observation order* in which `update` was
+/// actually invoked via a shared counter. The recorded order must match the
+/// registration order.
+#[test]
+fn same_time_events_fire_in_fifo_order() {
+    let counter = Rc::new(RefCell::new(0u32));
+    let observations: Rc<RefCell<Vec<(NodeId, u32)>>> = Rc::new(RefCell::new(Vec::new()));
+
+    struct RecordingNode {
+        id: NodeId,
+        counter: Rc<RefCell<u32>>,
+        observations: Rc<RefCell<Vec<(NodeId, u32)>>>,
+        wake_at: Option<SimTime>,
+    }
+
+    impl NodeHandle for RecordingNode {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _: RxMetadata, _: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&mut self, _: SimTime) -> Option<Transmission> {
+            None
+        }
+        fn update(&mut self, _: SimTime) -> Option<SimTime> {
+            let mut c = self.counter.borrow_mut();
+            *c += 1;
+            self.observations.borrow_mut().push((self.id, *c));
+            self.wake_at.take()
+        }
+    }
+
+    let mut sched = Scheduler::new(100_000);
+    for id in [1, 2, 3] {
+        sched.add_node(
+            Box::new(RecordingNode {
+                id: NodeId(id),
+                counter: Rc::clone(&counter),
+                observations: Rc::clone(&observations),
+                wake_at: None,
+            }),
+            Some(50_000),
+        );
+    }
+    sched.run();
+
+    let obs = observations.borrow();
+    assert_eq!(obs.len(), 3, "expected exactly 3 updates at the same time");
+    assert_eq!(
+        obs.iter().map(|(id, _)| id.0).collect::<Vec<_>>(),
+        vec![1, 2, 3],
+        "updates must fire in registration order when times are equal"
+    );
+}

--- a/tests/scheduler_invariants.rs
+++ b/tests/scheduler_invariants.rs
@@ -1,0 +1,442 @@
+//! Invariant tests for the scheduler-channel-metrics interaction.
+//!
+//! These tests pin down behaviour that the existing suite implicitly relies on
+//! but does not explicitly assert. Each section documents the invariant,
+//! sourced from the implementation in `src/scheduler.rs`:
+//!
+//! 1. A sender never receives its own transmission (the `if self.nodes[i].node_id() != sender`
+//!    guard in `deliver_completed_to_nodes`).
+//! 2. Collided frames are *not* delivered: `total_rx` only counts non-collided receptions
+//!    (the `if collided { record_collision } else { ... }` branch).
+//! 3. `total_rx` equals the sum of per-node receive counts (consistency between aggregate
+//!    and per-node `MetricsCollector` counters).
+//! 4. Cross-observation between interferers: when one interferer injects a frame, *all*
+//!    interferers — including itself — receive both the `TransmissionStarted` and
+//!    `TransmissionCompleted` channel events (the `for i in 0..self.interferers.len()`
+//!    loops in `handle_poll_transmit` analogues for the interference branch).
+//! 5. Same-time FIFO ordering: events scheduled at the same `SimTime` fire in insertion
+//!    order, because `ScheduledEvent::cmp` ties on `seq` (this is what makes the
+//!    simulation deterministic across reruns of identical scenarios).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use theatron::scheduler::{NodeHandle, Scheduler};
+use theatron::time::SimTime;
+use theatron::traits::InterferenceSource;
+use theatron::types::{ChannelEvent, NodeId, RxMetadata, Transmission};
+
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// (time, node_id, kind) — node-side event log.
+type NodeLog = Rc<RefCell<Vec<(SimTime, u32, &'static str)>>>;
+/// (time, label, kind, sender) — interferer-side event log.
+type InterfererLog = Rc<RefCell<Vec<(SimTime, &'static str, &'static str, NodeId)>>>;
+/// (time, node_id) — wake-only log.
+type WakeLog = Rc<RefCell<Vec<(SimTime, u32)>>>;
+
+fn tx(sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
+    Transmission {
+        payload: vec![0xAB],
+        sf,
+        bandwidth: 125_000,
+        coding_rate: 5,
+        frequency: freq,
+        duration_us: dur,
+        tx_power_dbm: power,
+    }
+}
+
+/// A node that can be configured to transmit once and to record an ordered log
+/// of `update`/`on_receive`/`poll_transmit` calls keyed by simulation time.
+struct LoggingNode {
+    id: NodeId,
+    pending_tx: Option<Transmission>,
+    /// Shared event log: (time, node_id, kind).
+    log: NodeLog,
+}
+
+impl LoggingNode {
+    fn new(id: u32, log: NodeLog, pending_tx: Option<Transmission>) -> Self {
+        Self {
+            id: NodeId(id),
+            pending_tx,
+            log,
+        }
+    }
+}
+
+impl NodeHandle for LoggingNode {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+    fn on_receive(&mut self, _frame: RxMetadata, time: SimTime) -> Option<SimTime> {
+        self.log.borrow_mut().push((time, self.id.0, "rx"));
+        None
+    }
+    fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+        let next = self.pending_tx.take();
+        if next.is_some() {
+            self.log.borrow_mut().push((time, self.id.0, "tx"));
+        }
+        next
+    }
+    fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        self.log.borrow_mut().push((time, self.id.0, "update"));
+        None
+    }
+}
+
+/// An interferer that records every channel event it observes.
+struct ObservingInterferer {
+    label: &'static str,
+    log: InterfererLog,
+    inject_once: Option<Transmission>,
+    first_poll_done: bool,
+}
+
+impl ObservingInterferer {
+    fn new(label: &'static str, log: InterfererLog, inject_once: Option<Transmission>) -> Self {
+        Self {
+            label,
+            log,
+            inject_once,
+            first_poll_done: false,
+        }
+    }
+}
+
+impl InterferenceSource for ObservingInterferer {
+    fn observe(&mut self, event: &ChannelEvent, time: SimTime) {
+        let (kind, sender) = match event {
+            ChannelEvent::TransmissionStarted { sender, .. } => ("started", *sender),
+            ChannelEvent::TransmissionCompleted { sender, .. } => ("completed", *sender),
+        };
+        self.log.borrow_mut().push((time, self.label, kind, sender));
+    }
+    fn poll_inject(&mut self, _time: SimTime) -> Option<Transmission> {
+        if self.first_poll_done {
+            return None;
+        }
+        self.first_poll_done = true;
+        self.inject_once.take()
+    }
+    fn next_poll_time(&self, _current_time: SimTime) -> Option<SimTime> {
+        None
+    }
+}
+
+/// Counts wakes and records the time of each.
+struct WakeCounter {
+    id: NodeId,
+    log: WakeLog,
+}
+
+impl NodeHandle for WakeCounter {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+    fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+        None
+    }
+    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+        None
+    }
+    fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        self.log.borrow_mut().push((time, self.id.0));
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 1: sender never receives its own transmission.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sender_never_receives_own_broadcast() {
+    let mut sched = Scheduler::new(200_000);
+    let log: NodeLog = Rc::new(RefCell::new(Vec::new()));
+    let sender = LoggingNode::new(1, log.clone(), Some(tx(7, 868_100_000, 50_000, 14)));
+    sched.add_node(Box::new(sender), Some(0));
+    sched.add_node(Box::new(LoggingNode::new(2, log.clone(), None)), None);
+    sched.add_node(Box::new(LoggingNode::new(3, log.clone(), None)), None);
+    sched.run();
+
+    // Sender never received anything; receivers each got exactly one frame.
+    assert_eq!(
+        sched.metrics.node_rx_count(NodeId(1)),
+        0,
+        "sender must not receive its own transmission"
+    );
+    assert_eq!(sched.metrics.node_rx_count(NodeId(2)), 1);
+    assert_eq!(sched.metrics.node_rx_count(NodeId(3)), 1);
+
+    // No "rx" entry should be present for node 1 in the log.
+    let log = log.borrow();
+    assert!(
+        log.iter().all(|(_, id, kind)| !(*id == 1 && *kind == "rx")),
+        "log should contain no rx entry for the sender; got: {:?}",
+        log
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 2: collided frames are not delivered.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn collided_frames_are_not_delivered() {
+    let mut sched = Scheduler::new(200_000);
+    let log = Rc::new(RefCell::new(Vec::new()));
+
+    sched.add_node(
+        Box::new(LoggingNode::new(
+            1,
+            log.clone(),
+            Some(tx(7, 868_100_000, 50_000, 14)),
+        )),
+        Some(0),
+    );
+    sched.add_node(
+        Box::new(LoggingNode::new(
+            2,
+            log.clone(),
+            Some(tx(7, 868_100_000, 50_000, 14)),
+        )),
+        Some(10_000),
+    );
+    // A passive receiver: should observe nothing because both senders collide.
+    sched.add_node(Box::new(LoggingNode::new(3, log.clone(), None)), None);
+    sched.run();
+
+    assert_eq!(sched.metrics.total_tx, 2);
+    assert_eq!(sched.metrics.total_collisions, 2);
+    assert_eq!(
+        sched.metrics.total_rx, 0,
+        "collided frames must not be counted as receptions"
+    );
+    let log = log.borrow();
+    assert!(
+        log.iter().all(|(_, _, kind)| *kind != "rx"),
+        "no node's on_receive should fire for collided frames; got: {:?}",
+        log
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 3: aggregate total_rx == sum of per-node rx counts.
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #[test]
+    fn aggregate_total_rx_equals_sum_of_per_node(n_receivers in 1usize..10) {
+        let mut sched = Scheduler::new(200_000);
+        sched.add_node(
+            Box::new(LoggingNode::new(
+                0,
+                Rc::new(RefCell::new(Vec::new())),
+                Some(tx(7, 868_100_000, 50_000, 14)),
+            )),
+            Some(0),
+        );
+        for i in 1..=n_receivers {
+            sched.add_node(
+                Box::new(LoggingNode::new(
+                    i as u32,
+                    Rc::new(RefCell::new(Vec::new())),
+                    None,
+                )),
+                None,
+            );
+        }
+        sched.run();
+
+        let mut sum = 0u64;
+        for i in 0..=n_receivers {
+            sum += sched.metrics.node_rx_count(NodeId(i as u32));
+        }
+        prop_assert_eq!(sched.metrics.total_rx, sum);
+        prop_assert_eq!(sched.metrics.total_rx, n_receivers as u64);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 4: all interferers observe channel events for any interferer-injected
+// transmission (started + completed), not just node-originated ones. This is the
+// behaviour relied upon by passive eavesdroppers and adversarial replay models
+// from ARCHITECTURE.md.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_interferers_observe_interferer_originated_events() {
+    let mut sched = Scheduler::new(300_000);
+    let log: InterfererLog = Rc::new(RefCell::new(Vec::new()));
+
+    // Active interferer that injects exactly one transmission at t=0.
+    let active =
+        ObservingInterferer::new("active", log.clone(), Some(tx(7, 868_100_000, 50_000, 14)));
+    // Passive interferer that only observes.
+    let passive = ObservingInterferer::new("passive", log.clone(), None);
+
+    sched.add_interferer(Box::new(active), 0);
+    sched.add_interferer(Box::new(passive), 0);
+    sched.run();
+
+    // Each interferer should see one "started" and one "completed" for the
+    // interferer-originated TX. Synthetic interferer NodeIds occupy the top of
+    // the u32 range (u32::MAX, u32::MAX-1).
+    let log = log.borrow();
+    let active_started = log
+        .iter()
+        .filter(|(_, l, k, _)| *l == "active" && *k == "started")
+        .count();
+    let passive_started = log
+        .iter()
+        .filter(|(_, l, k, _)| *l == "passive" && *k == "started")
+        .count();
+    let active_completed = log
+        .iter()
+        .filter(|(_, l, k, _)| *l == "active" && *k == "completed")
+        .count();
+    let passive_completed = log
+        .iter()
+        .filter(|(_, l, k, _)| *l == "passive" && *k == "completed")
+        .count();
+
+    assert_eq!(
+        active_started, 1,
+        "active interferer must observe its own started event"
+    );
+    assert_eq!(
+        passive_started, 1,
+        "passive interferer must observe other interferers' started events"
+    );
+    assert_eq!(active_completed, 1);
+    assert_eq!(passive_completed, 1);
+}
+
+#[test]
+fn passive_interferer_observes_node_transmissions() {
+    let mut sched = Scheduler::new(200_000);
+    let log: InterfererLog = Rc::new(RefCell::new(Vec::new()));
+    let passive = ObservingInterferer::new("eavesdropper", log.clone(), None);
+    sched.add_interferer(Box::new(passive), 0);
+
+    let node_log = Rc::new(RefCell::new(Vec::new()));
+    sched.add_node(
+        Box::new(LoggingNode::new(
+            1,
+            node_log,
+            Some(tx(7, 868_100_000, 50_000, 14)),
+        )),
+        Some(0),
+    );
+    sched.run();
+
+    let log = log.borrow();
+    let started: Vec<_> = log.iter().filter(|(_, _, k, _)| *k == "started").collect();
+    let completed: Vec<_> = log
+        .iter()
+        .filter(|(_, _, k, _)| *k == "completed")
+        .collect();
+    assert_eq!(started.len(), 1, "passive must observe node TX start");
+    assert_eq!(
+        completed.len(),
+        1,
+        "passive must observe node TX completion"
+    );
+    assert_eq!(started[0].3, NodeId(1));
+    assert_eq!(completed[0].3, NodeId(1));
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 5: same-time FIFO ordering for determinism.
+//
+// Two PeriodicNodes scheduled with `initial_wake = Some(0)` both fire at t=0.
+// The seq tie-breaker in ScheduledEvent::cmp guarantees that the node added
+// first wakes first — and that the order does not depend on HashMap or
+// BinaryHeap internal randomization.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_time_events_fire_in_insertion_order() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let mut sched = Scheduler::new(100);
+
+    sched.add_node(
+        Box::new(WakeCounter {
+            id: NodeId(10),
+            log: log.clone(),
+        }),
+        Some(0),
+    );
+    sched.add_node(
+        Box::new(WakeCounter {
+            id: NodeId(20),
+            log: log.clone(),
+        }),
+        Some(0),
+    );
+    sched.add_node(
+        Box::new(WakeCounter {
+            id: NodeId(30),
+            log: log.clone(),
+        }),
+        Some(0),
+    );
+    sched.run();
+
+    let events = log.borrow().clone();
+    assert_eq!(events.len(), 3);
+    // Each fires at t=0, in the order they were added.
+    assert_eq!(events[0], (0, 10));
+    assert_eq!(events[1], (0, 20));
+    assert_eq!(events[2], (0, 30));
+}
+
+#[test]
+fn rerunning_identical_scenario_produces_identical_metrics() {
+    fn run_once() -> (u64, u64, u64, u64, u64) {
+        let mut sched = Scheduler::new(500_000);
+        // Two senders that will collide, plus three passive listeners.
+        sched.add_node(
+            Box::new(LoggingNode::new(
+                1,
+                Rc::new(RefCell::new(Vec::new())),
+                Some(tx(7, 868_100_000, 50_000, 20)),
+            )),
+            Some(0),
+        );
+        sched.add_node(
+            Box::new(LoggingNode::new(
+                2,
+                Rc::new(RefCell::new(Vec::new())),
+                Some(tx(7, 868_100_000, 50_000, 14)),
+            )),
+            Some(10_000),
+        );
+        for i in 3..=5 {
+            sched.add_node(
+                Box::new(LoggingNode::new(i, Rc::new(RefCell::new(Vec::new())), None)),
+                None,
+            );
+        }
+        sched.run();
+        (
+            sched.metrics.total_tx,
+            sched.metrics.total_rx,
+            sched.metrics.total_collisions,
+            sched.metrics.total_captures,
+            sched.metrics.total_airtime_us,
+        )
+    }
+    let a = run_once();
+    let b = run_once();
+    let c = run_once();
+    assert_eq!(a, b, "scheduler must be deterministic across reruns");
+    assert_eq!(b, c);
+}


### PR DESCRIPTION
## Summary

- Adds `src/aloha.rs` — a self-contained Pure ALOHA MAC protocol implementation with no new production dependencies
- Adds `examples/aloha/main.rs` — runnable simulation with 3 nodes at ~0.1 pkt/s for 10 s, printing TX/RX/collision/throughput stats
- Adds `tests/aloha.rs` — three integration tests covering single-node delivery, multi-node collision, and backoff retransmission timing
- Registers the new `[[example]] name = "aloha"` entry in `Cargo.toml`
- Exports `pub mod aloha` from `src/lib.rs`

## What was implemented

### `src/aloha.rs`

**`Xorshift64`** — minimal deterministic PRNG (no external crate; `rand_core` is dev-only so cannot be used in lib code). Implements rejection-sampling `next_u64_below(range)` to avoid modulo bias.

**`PoissonTraffic`** — implements `TrafficModel`. Draws inter-arrival times from `U(mean/2, 3·mean/2)` (correct mean, integer arithmetic only). Tracks the next absolute arrival time; `next_payload(time)` returns `Some(payload)` only when `time >= next_arrival`.

**`AlohaNode<T: TrafficModel>`** — implements `NodeHandle` via a four-phase state machine:

```
Idle ──(payload ready)──► ReadyToTransmit
  ▲                             │
  │                     poll_transmit() called
  │                             │
  │                  AwaitingBackoffStart { duration_us }
  │                             │
  │                     next update(time) call
  │                             │
  │                   Backoff { until = time + duration_us }
  │                             │
  └──────(until reached)────────┘
```

Key design choice: `poll_transmit` does not receive the current time, so the relative backoff duration is stored in `AwaitingBackoffStart`; the absolute deadline is computed in the following `update` call. This ensures the backoff starts from the post-TX timestamp provided by the scheduler, not a stale value.

Physical parameters: SF7, BW=125 kHz, duration≈56 ms, freq=868.1 MHz, TX power=14 dBm.

### `examples/aloha/main.rs`

Three independent `AlohaNode<PoissonTraffic>` nodes at ~0.1 pkt/s (mean inter-arrival 10 s), backoff window 2× on-air time. Runs for 10 s of simulated time and prints:
- Total TX / RX / collisions
- Throughput in pkt/s

### `tests/aloha.rs`

| Test | Scenario | Assertion |
|---|---|---|
| `single_node_delivery` | 1 sender, 1 receiver, `FireOnce` at t=0 | `total_tx=1`, `total_rx=1`, `total_collisions=0` |
| `multi_node_collision` | 2 senders both fire at t=0, same SF/freq | `total_tx=2`, `total_collisions≥2`, `total_rx=0` |
| `backoff_retransmission` | `NShot(2)` with 200 ms backoff, `RecordingNode` shim | second TX time > first TX time, gap ≥ `LORA_SF7_DURATION_US` |

## Acceptance criteria (from issue #11)

- [x] Pure ALOHA example in `examples/aloha/` with a runnable simulation
- [x] Integration tests: single-node delivery, multi-node collision, backoff retransmission
- [ ] CI checks pass (fmt, clippy, test, coverage) — to be verified by CI run

## Test plan

```
cargo test                          # all unit + integration tests
cargo run --example aloha           # runnable example
cargo clippy -- -D warnings         # lints
cargo fmt --check                   # formatting
```

Closes #11