### PR TITLE
feat: kani-based verification with 13 proof harnesses (#30)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ lora-modulation = { git = "https://github.com/lora-rs/lora-rs", rev = "597beac2a
 proptest = "1"
 rand_core = { version = "0.6", default-features = false }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -272,6 +272,59 @@ fn overlaps(a_start: SimTime, a_end: SimTime, b_start: SimTime, b_end: SimTime) 
     a_start < b_end && b_start < a_end
 }
 
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn overlaps_reflexive() {
+        let start: u64 = kani::any();
+        let end: u64 = kani::any();
+        kani::assume(start < end);
+        assert!(overlaps(start, end, start, end));
+    }
+
+    #[kani::proof]
+    fn overlaps_symmetric() {
+        let a_start: u64 = kani::any();
+        let a_end: u64 = kani::any();
+        let b_start: u64 = kani::any();
+        let b_end: u64 = kani::any();
+        kani::assume(a_start < a_end);
+        kani::assume(b_start < b_end);
+        assert_eq!(
+            overlaps(a_start, a_end, b_start, b_end),
+            overlaps(b_start, b_end, a_start, a_end)
+        );
+    }
+
+    #[kani::proof]
+    fn overlaps_adjacent_is_false() {
+        let a_start: u64 = kani::any();
+        let duration_a: u64 = kani::any();
+        let duration_b: u64 = kani::any();
+        kani::assume(duration_a > 0 && duration_a < 1_000_000);
+        kani::assume(duration_b > 0 && duration_b < 1_000_000);
+        kani::assume(a_start < u64::MAX - duration_a - duration_b);
+        let a_end = a_start + duration_a;
+        let b_start = a_end; // adjacent, not overlapping
+        let b_end = b_start + duration_b;
+        assert!(!overlaps(a_start, a_end, b_start, b_end));
+    }
+
+    #[kani::proof]
+    fn compute_rssi_snr_finite() {
+        let tx_power: i8 = kani::any();
+        let ch = Channel::new();
+        let rssi = ch.compute_rssi(tx_power);
+        let snr = ch.compute_snr(rssi);
+        assert!(rssi.is_finite());
+        assert!(snr.is_finite());
+        // SNR = rssi - noise_floor = (tx_power - path_loss) - noise_floor
+        // All inputs are finite, so result must be finite.
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -125,6 +125,55 @@ impl MetricsCollector {
     }
 }
 
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    /// Verify that record_tx cannot overflow within a bounded simulation.
+    /// A 24-hour simulation at 1 TX per microsecond = 86_400_000_000 TXs,
+    /// which fits comfortably in u64.
+    #[kani::proof]
+    fn record_tx_no_overflow() {
+        let mut m = MetricsCollector::new();
+        let initial: u64 = kani::any();
+        kani::assume(initial < u64::MAX - 1);
+        m.total_tx = initial;
+        m.record_tx(NodeId(1));
+        assert_eq!(m.total_tx, initial + 1);
+    }
+
+    #[kani::proof]
+    fn record_rx_no_overflow() {
+        let mut m = MetricsCollector::new();
+        let initial: u64 = kani::any();
+        kani::assume(initial < u64::MAX - 1);
+        m.total_rx = initial;
+        m.record_rx(NodeId(1));
+        assert_eq!(m.total_rx, initial + 1);
+    }
+
+    #[kani::proof]
+    fn record_collision_no_overflow() {
+        let mut m = MetricsCollector::new();
+        let initial: u64 = kani::any();
+        kani::assume(initial < u64::MAX - 1);
+        m.total_collisions = initial;
+        m.record_collision();
+        assert_eq!(m.total_collisions, initial + 1);
+    }
+
+    #[kani::proof]
+    fn record_airtime_no_overflow() {
+        let mut m = MetricsCollector::new();
+        let initial: u64 = kani::any();
+        let duration: u64 = kani::any();
+        kani::assume(initial <= u64::MAX - duration);
+        m.total_airtime_us = initial;
+        m.record_airtime(duration);
+        assert_eq!(m.total_airtime_us, initial + duration);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -313,6 +313,89 @@ impl Scheduler {
     }
 }
 
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn scheduled_event_ord_consistent() {
+        let time_a: u64 = kani::any();
+        let seq_a: u64 = kani::any();
+        let time_b: u64 = kani::any();
+        let seq_b: u64 = kani::any();
+
+        let a = ScheduledEvent {
+            time: time_a,
+            seq: seq_a,
+            kind: EventKind::Wake {
+                node_id: crate::types::NodeId(0),
+            },
+        };
+        let b = ScheduledEvent {
+            time: time_b,
+            seq: seq_b,
+            kind: EventKind::Wake {
+                node_id: crate::types::NodeId(0),
+            },
+        };
+
+        // Verify Ord is consistent with PartialOrd
+        assert_eq!(a.partial_cmp(&b), Some(a.cmp(&b)));
+
+        // Verify antisymmetry: if a <= b and b <= a then a == b (in ordering)
+        if a.cmp(&b) == Ordering::Equal {
+            assert_eq!(b.cmp(&a), Ordering::Equal);
+        }
+
+        // Verify the min-heap inversion: earlier time => Greater ordering
+        // (BinaryHeap is a max-heap, so we reverse to get min-heap behavior)
+        if time_a < time_b {
+            assert!(a.cmp(&b) == Ordering::Greater || a.cmp(&b) == Ordering::Equal);
+        }
+    }
+
+    #[kani::proof]
+    fn scheduled_event_ord_transitive() {
+        let t1: u64 = kani::any();
+        let t2: u64 = kani::any();
+        let t3: u64 = kani::any();
+        let s1: u64 = kani::any();
+        let s2: u64 = kani::any();
+        let s3: u64 = kani::any();
+
+        let kind = EventKind::Wake {
+            node_id: crate::types::NodeId(0),
+        };
+
+        let a = ScheduledEvent {
+            time: t1,
+            seq: s1,
+            kind: kind.clone(),
+        };
+        let b = ScheduledEvent {
+            time: t2,
+            seq: s2,
+            kind: kind.clone(),
+        };
+        let c = ScheduledEvent {
+            time: t3,
+            seq: s3,
+            kind: kind.clone(),
+        };
+
+        // Transitivity: if a >= b and b >= c then a >= c
+        let ab = a.cmp(&b);
+        let bc = b.cmp(&c);
+        let ac = a.cmp(&c);
+
+        if (ab == Ordering::Greater || ab == Ordering::Equal)
+            && (bc == Ordering::Greater || bc == Ordering::Equal)
+        {
+            assert!(ac == Ordering::Greater || ac == Ordering::Equal);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/time.rs
+++ b/src/time.rs
@@ -33,6 +33,36 @@ pub fn ms_to_sim_time(ms: u32) -> SimTime {
     ms as u64 * 1_000
 }
 
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn ms_to_sim_time_no_overflow() {
+        let ms: u32 = kani::any();
+        let result = ms_to_sim_time(ms);
+        // u32::MAX * 1_000 fits in u64, so no overflow is possible.
+        assert!(result >= ms as u64);
+        assert_eq!(result, ms as u64 * 1_000);
+    }
+
+    #[kani::proof]
+    fn sim_time_to_ms_consistent() {
+        let t: u64 = kani::any();
+        let ms = sim_time_to_ms(t);
+        assert!(ms <= t);
+        assert_eq!(ms, t / 1_000);
+    }
+
+    #[kani::proof]
+    fn ms_round_trip() {
+        let ms: u32 = kani::any();
+        let sim = ms_to_sim_time(ms);
+        let back = sim_time_to_ms(sim);
+        assert_eq!(back, ms as u64);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
# Summary

- **#30**: Add kani-based formal verification with 13 proof harnesses across 4 modules:
  - `src/time.rs`: 3 proofs (ms_to_sim_time overflow, conversion consistency, round-trip)
  - `src/channel.rs`: 4 proofs (overlaps reflexive/symmetric/adjacent, RSSI/SNR finiteness)
  - `src/metrics.rs`: 4 proofs (record_tx/rx/collision/airtime overflow)
  - `src/scheduler.rs`: 2 proofs (ScheduledEvent Ord consistency and transitivity)
- Adds `check-cfg = ['cfg(kani)']` workspace lint config

## Incomplete work

- `.github/workflows/kani.yml` created locally but could not be pushed (GitHub App token lacks `workflows` permission). Contents:
```yaml
name: Kani Verification
on:
  push:
    branches: [main]
  pull_request:
jobs:
  kani:
    name: Kani Proofs
    runs-on: ubuntu-latest
    timeout-minutes: 30
    steps:
      - uses: actions/checkout@v4
      - uses: model-checking/kani-github-action@v1
```

## Next steps (sub-issues unblocked by this foundation)

- #31: SimTime arithmetic overflow proofs (cross-module)
- #32-#33: Channel collision + capture effect proofs
- #34: Scheduler event ordering proofs
- #35: Interferer ID collision proof + fix
- #36: Metrics counter safe bounds
- #37: Protocol trait contract proofs

## Test plan

- [x] `cargo check` passes
- [ ] Add kani.yml workflow (requires `workflows` permission)
- [ ] Verify kani proofs pass in CI