### PR TITLE
[theatron] [Testing]: Fix two broken example tests, add scheduler/metrics/fragmenter coverage

### DIFF
--- a/examples/lorawan_file_transfer/file_fragmenter.rs
+++ b/examples/lorawan_file_transfer/file_fragmenter.rs
@@ -71,4 +71,40 @@ mod tests {
         assert_eq!(f.next_payload(500), None);
         assert_eq!(f.next_payload(1_000), Some(vec![3, 4]));
     }
+
+    #[test]
+    fn is_done_false_initially_true_after_exhaustion() {
+        let data = vec![1u8, 2, 3];
+        let mut f = FileFragmenter::new(data, 10, 0);
+        assert!(
+            !f.is_done(),
+            "should not be done before any payload is taken"
+        );
+        f.next_payload(0);
+        assert!(f.is_done(), "should be done after all data is consumed");
+    }
+
+    #[test]
+    fn empty_data_is_immediately_done() {
+        let f = FileFragmenter::new(vec![], 4, 0);
+        assert!(f.is_done());
+    }
+
+    #[test]
+    fn next_available_time_none_when_done() {
+        let mut f = FileFragmenter::new(vec![1u8], 10, 0);
+        f.next_payload(0);
+        assert!(f.next_available_time(0).is_none());
+        assert!(f.next_available_time(1_000_000).is_none());
+    }
+
+    #[test]
+    fn next_available_time_returns_future_when_interval_not_elapsed() {
+        let data = vec![1u8, 2, 3, 4];
+        let mut f = FileFragmenter::new(data, 2, 5_000);
+        f.next_payload(0); // next_send = 5_000
+        assert_eq!(f.next_available_time(0), Some(5_000));
+        assert_eq!(f.next_available_time(4_999), Some(5_000));
+        assert_eq!(f.next_available_time(5_000), Some(5_000));
+    }
 }

--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -175,8 +175,36 @@ mod tests {
     #[test]
     fn inject_downlink_populates_rx_buf() {
         let mut radio = SimulatedRadio::new();
-        radio.inject_downlink(vec![0x01, 0x02, 0x03]);
+        // Must set up an active RX config before inject_downlink will accept data.
+        let rf = make_rf();
+        let sf = rf.bb.sf.factor() as u8;
+        let freq = rf.frequency;
+        radio.handle_event(Event::RxRequest(rf)).unwrap();
+        let accepted = radio.inject_downlink(vec![0x01, 0x02, 0x03], sf, freq);
+        assert!(
+            accepted,
+            "inject_downlink should succeed when RX config matches"
+        );
         assert_eq!(radio.get_received_packet(), &[0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn inject_downlink_rejected_without_rx_config() {
+        let mut radio = SimulatedRadio::new();
+        let accepted = radio.inject_downlink(vec![0xAB], 7, 868_100_000);
+        assert!(
+            !accepted,
+            "inject_downlink must return false when not in RX mode"
+        );
+    }
+
+    #[test]
+    fn inject_downlink_rejected_on_sf_mismatch() {
+        let mut radio = SimulatedRadio::new();
+        radio.handle_event(Event::RxRequest(make_rf())).unwrap();
+        // make_rf uses SF7; inject with SF8 should be rejected.
+        let accepted = radio.inject_downlink(vec![0xAB], 8, 868_100_000);
+        assert!(!accepted, "inject_downlink must reject mismatched SF");
     }
 
     #[test]
@@ -207,7 +235,12 @@ mod tests {
     #[test]
     fn phy_with_downlink_returns_rx_done() {
         let mut radio = SimulatedRadio::new();
-        radio.inject_downlink(vec![0xAB]);
+        let rf = make_rf();
+        let sf = rf.bb.sf.factor() as u8;
+        let freq = rf.frequency;
+        radio.handle_event(Event::RxRequest(rf)).unwrap();
+        let accepted = radio.inject_downlink(vec![0xAB], sf, freq);
+        assert!(accepted);
         let result = radio.handle_event(Event::Phy(()));
         assert!(matches!(result, Ok(Response::RxDone(_))));
     }
@@ -222,7 +255,7 @@ mod tests {
     #[test]
     fn timings_values() {
         let radio = SimulatedRadio::new();
-        assert_eq!(radio.get_rx_window_offset_ms(), 0);
-        assert_eq!(radio.get_rx_window_duration_ms(), 100);
+        assert_eq!(radio.get_rx_window_offset_ms(), RX_WINDOW_OFFSET_MS);
+        assert_eq!(radio.get_rx_window_duration_ms(), RX_WINDOW_DURATION_MS);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,6 +73,16 @@ impl MetricsCollector {
         self.total_collisions += 1;
     }
 
+    /// Record a capture event (a stronger signal overpowering a weaker one).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::metrics::MetricsCollector;
+    /// let mut m = MetricsCollector::new();
+    /// m.record_capture();
+    /// assert_eq!(m.total_captures, 1);
+    /// ```
     pub fn record_capture(&mut self) {
         self.total_captures += 1;
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -716,6 +716,69 @@ mod tests {
         assert_eq!(sched.metrics.total_rx, 0, "collision prevents delivery");
     }
 
+    #[test]
+    fn current_time_advances_to_tx_end() {
+        // The scheduler must advance current_time to the TxComplete event
+        // time (= tx start + duration), not just to the initial wake.
+        let duration_us = 75_000u64;
+        let wake_at = 10_000u64;
+        let mut sched = Scheduler::new(200_000);
+        let mut node = SimpleNode::new(1);
+        node.queue_tx(make_tx(7, 868_100_000, duration_us));
+        sched.add_node(Box::new(node), Some(wake_at));
+        sched.run();
+        // After the TX completes the scheduler must have processed the
+        // TxComplete event at wake_at + duration_us.
+        assert_eq!(
+            sched.current_time(),
+            wake_at + duration_us,
+            "current_time must reach the TX completion point"
+        );
+    }
+
+    #[test]
+    fn total_rx_equals_sum_of_per_node_counts() {
+        // Invariant: metrics.total_rx == sum of node_rx_count for every node
+        // that received at least one frame.
+        let mut sched = Scheduler::new(200_000);
+        let mut sender = SimpleNode::new(1);
+        sender.queue_tx(make_tx(7, 868_100_000, 50_000));
+        sched.add_node(Box::new(sender), Some(0));
+        sched.add_node(Box::new(SimpleNode::new(2)), None);
+        sched.add_node(Box::new(SimpleNode::new(3)), None);
+        sched.add_node(Box::new(SimpleNode::new(4)), None);
+        sched.run();
+
+        let per_node_sum: u64 = [1u32, 2, 3, 4]
+            .iter()
+            .map(|&id| sched.metrics.node_rx_count(NodeId(id)))
+            .sum();
+        assert_eq!(
+            sched.metrics.total_rx, per_node_sum,
+            "total_rx must equal the sum of all per-node rx counts"
+        );
+    }
+
+    #[test]
+    fn total_tx_equals_sum_of_per_node_counts() {
+        // Invariant: metrics.total_tx == sum of node_tx_count for every node.
+        let mut sched = Scheduler::new(200_000);
+        for i in 1u32..=3 {
+            let mut node = SimpleNode::new(i);
+            node.queue_tx(make_tx(7, 868_100_000 + i as u32 * 200_000, 50_000));
+            sched.add_node(Box::new(node), Some(0));
+        }
+        sched.run();
+
+        let per_node_sum: u64 = (1u32..=3)
+            .map(|id| sched.metrics.node_tx_count(NodeId(id)))
+            .sum();
+        assert_eq!(
+            sched.metrics.total_tx, per_node_sum,
+            "total_tx must equal the sum of all per-node tx counts"
+        );
+    }
+
     proptest! {
         #[test]
         fn n_receivers_all_get_broadcast(n in 2usize..20) {
@@ -729,6 +792,25 @@ mod tests {
             sched.run();
             prop_assert_eq!(sched.metrics.total_tx, 1u64);
             prop_assert_eq!(sched.metrics.total_rx, n as u64);
+        }
+
+        #[test]
+        fn total_rx_never_exceeds_tx_times_receivers(n_receivers in 1usize..10) {
+            // With one sender and n receivers, total_rx <= total_tx * n_receivers.
+            // (Equality holds when there are no collisions.)
+            let mut sched = Scheduler::new(200_000);
+            let mut sender = SimpleNode::new(0);
+            sender.queue_tx(make_tx(7, 868_100_000, 50_000));
+            sched.add_node(Box::new(sender), Some(0));
+            for i in 1..=n_receivers {
+                sched.add_node(Box::new(SimpleNode::new(i as u32)), None);
+            }
+            sched.run();
+            prop_assert!(
+                sched.metrics.total_rx <= sched.metrics.total_tx * n_receivers as u64,
+                "total_rx={} must be <= total_tx={} * n_receivers={}",
+                sched.metrics.total_rx, sched.metrics.total_tx, n_receivers
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

**Bug fixes — tests that never compiled or ran:**
- `simulated_radio.rs`: `inject_downlink_populates_rx_buf` and `phy_with_downlink_returns_rx_done` called `inject_downlink` with 1 argument but the method requires 3 (`data`, `sf`, `frequency`). Fixed to set up a matching `RxRequest` first and pass the correct SF/frequency.
- `simulated_radio.rs`: `timings_values` hardcoded `100` for `get_rx_window_duration_ms()` but the constant is `1000`. Fixed to compare against the named constants.

**New unit tests:**
- Two new `inject_downlink` tests for the rejection paths: no active RX config, and SF mismatch — these were untested branches.
- `MetricsCollector::record_capture` doctest added — every other public method had one; this was the only gap.
- `FileFragmenter::is_done`, `empty_data_is_immediately_done`, `next_available_time_none_when_done`, `next_available_time_returns_future_when_interval_not_elapsed` — `is_done` was marked `#[allow(dead_code)]` with zero coverage.
- `Scheduler::current_time_advances_to_tx_end` — pins that `current_time()` reaches the `TxComplete` event time, not just the wake time.
- `total_rx_equals_sum_of_per_node_counts` and `total_tx_equals_sum_of_per_node_counts` — assert the invariant that aggregate counters always equal the sum of per-node counters.
- Property test `total_rx_never_exceeds_tx_times_receivers` — generalises the delivery bound across arbitrary receiver counts.

## Test plan

- [ ] `cargo test` passes (all unit and integration tests green)
- [ ] `cargo test --example lorawan_file_transfer` passes (previously 2 tests failed to compile)
- [ ] All doc-tests pass
- [ ] No existing test behavior changed

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF