### PR TITLE
arch: add missing doc comment to MetricsCollector::record_capture

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,6 +73,17 @@ impl MetricsCollector {
         self.total_collisions += 1;
     }
 
+    /// Record a capture event (a frame successfully decoded despite a simultaneous
+    /// transmission on the same channel, via the radio capture effect).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use theatron::metrics::MetricsCollector;
+    /// let mut m = MetricsCollector::new();
+    /// m.record_capture();
+    /// assert_eq!(m.total_captures, 1);
+    /// ```
     pub fn record_capture(&mut self) {
         self.total_captures += 1;
     }


### PR DESCRIPTION
## Summary

`MetricsCollector::record_capture` was the only public method in `metrics.rs`
lacking a doc comment and example, breaking the consistency established by all
other methods in the same impl block.

### Change
- Added `///` doc comment + `# Examples` doctest to `record_capture()`, matching
  the style of `record_tx`, `record_rx`, `record_collision`, and `record_airtime`.

### Also noted (not fixed — separate concern)
- `MetricsCollector::new()` is an alias for `Self::default()`. The constructor
  is part of the public API so removing it would be a breaking change, but future
  semver-major releases should consider dropping it in favour of the `Default`
  derive.