### PR TITLE
docs(theatron): reduce bloat and standardize formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Theatron
 
 [![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
-[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron/blob/main/LICENSE-MIT)
-[![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
+[![Codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron/blob/main/LICENSE-MIT)
 
 Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.


### PR DESCRIPTION
Remove the redundant "last commit" badge (duplicates GitHub UI) and standardize badge label casing to title case (`Codecov`, `License`).