### PR TITLE
arch(theatron): reduce complexity and improve alignment

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -53,7 +53,8 @@ pub trait NodeHandle {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum EventKind {
     Wake { node_id: NodeId },
-    TxComplete { sender: NodeId },
+    /// Fired when a transmission window closes; the channel resolves overlap at this point.
+    TxComplete,
     InterferencePoll { interferer_idx: usize },
 }
 
@@ -168,10 +169,6 @@ impl Scheduler {
         self.events.push(ScheduledEvent { time, seq, kind });
     }
 
-    fn find_node_idx(&self, id: NodeId) -> Option<usize> {
-        self.nodes.iter().position(|n| n.node_id() == id)
-    }
-
     fn handle_poll_transmit(&mut self, node_idx: usize, time: SimTime) {
         if let Some(tx) = self.nodes[node_idx].poll_transmit(time) {
             let sender = self.nodes[node_idx].node_id();
@@ -183,7 +180,7 @@ impl Scheduler {
             self.metrics.record_tx(sender);
             self.metrics.record_airtime(duration);
             let complete_time = time + duration;
-            self.schedule(complete_time, EventKind::TxComplete { sender });
+            self.schedule(complete_time, EventKind::TxComplete);
         }
     }
 
@@ -196,7 +193,10 @@ impl Scheduler {
                 if captured {
                     self.metrics.record_capture();
                 }
+                // Single pass: deliver frame, collect wake requests, and queue
+                // poll_transmit checks — avoids iterating the node list twice.
                 let mut wakes = Vec::new();
+                let mut tx_node_idxs = Vec::new();
                 for i in 0..self.nodes.len() {
                     if self.nodes[i].node_id() != sender {
                         let next = self.nodes[i].on_receive(frame.clone(), time);
@@ -204,16 +204,11 @@ impl Scheduler {
                         if let Some(t) = next {
                             wakes.push((self.nodes[i].node_id(), t));
                         }
+                        tx_node_idxs.push(i);
                     }
                 }
                 for (node_id, t) in wakes {
                     self.schedule(t, EventKind::Wake { node_id });
-                }
-                let mut tx_node_idxs = Vec::new();
-                for i in 0..self.nodes.len() {
-                    if self.nodes[i].node_id() != sender {
-                        tx_node_idxs.push(i);
-                    }
                 }
                 for i in tx_node_idxs {
                     self.handle_poll_transmit(i, time);
@@ -253,7 +248,7 @@ impl Scheduler {
 
             match event.kind {
                 EventKind::Wake { node_id } => {
-                    if let Some(idx) = self.find_node_idx(node_id) {
+                    if let Some(idx) = self.nodes.iter().position(|n| n.node_id() == node_id) {
                         let next = self.nodes[idx].update(event.time);
                         if let Some(t) = next {
                             self.schedule(t, EventKind::Wake { node_id });
@@ -261,7 +256,7 @@ impl Scheduler {
                         self.handle_poll_transmit(idx, event.time);
                     }
                 }
-                EventKind::TxComplete { sender: _ } => {
+                EventKind::TxComplete => {
                     let completed_events = self.channel.resolve_at(event.time);
                     for ch_event in &completed_events {
                         for interferer in &mut self.interferers {
@@ -285,9 +280,7 @@ impl Scheduler {
                         let complete_time = time + duration;
                         self.schedule(
                             complete_time,
-                            EventKind::TxComplete {
-                                sender: interferer_node_id,
-                            },
+                            EventKind::TxComplete,
                         );
                     }
                     let next = self.interferers[interferer_idx].next_poll_time(time);


### PR DESCRIPTION
## Issues addressed

- **Duplicate node-list iteration in `deliver_completed_to_nodes`** — the method looped over all nodes twice with the identical `node_id() != sender` guard: once for `on_receive` + wake collection, then again to build `tx_node_idxs`. Merged into a single pass that collects both in one traversal.
- **Dead `sender` field on `TxComplete` event** — `EventKind::TxComplete { sender }` carried a `NodeId` that was always bound to `_` at every match site and never read. Replaced with a unit-like variant `TxComplete` to eliminate the field and the dead construction of it in both `handle_poll_transmit` and the `InterferencePoll` arm.
- **Unnecessary `find_node_idx` helper** — a private one-call wrapper around `Iterator::position` that added a layer of indirection without clarity benefit. Inlined the `position` call directly into the `Wake` match arm where it was used.