### PR TITLE
test: lock in scheduler ordering + end_time invariants (plus dead-code debloat)

### DIFF
--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -1,4 +1,4 @@
-use lora_modulation::{Bandwidth, BaseBandModulationParams, CodingRate, SpreadingFactor};
+use lora_modulation::BaseBandModulationParams;
 use lorawan_device::Timings;
 use lorawan_device::nb_device::radio::{Event, PhyRxTx, Response, RfConfig, RxQuality, TxConfig};
 
@@ -135,6 +135,7 @@ impl Timings for SimulatedRadio {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 
     const TEST_SF: u8 = 7;
     const TEST_FREQ: u32 = 868_100_000;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -321,13 +321,16 @@ impl Channel {
         self.completed
             .iter()
             .filter(|tx| tx.end <= time && !tx.collided)
-            .map(|tx| RxMetadata {
-                payload: tx.payload.clone(),
-                rssi: self.compute_rssi(tx.tx_power_dbm),
-                snr: self.compute_snr(self.compute_rssi(tx.tx_power_dbm)),
-                sf: tx.sf,
-                frequency: tx.frequency,
-                time: tx.end,
+            .map(|tx| {
+                let rssi = self.compute_rssi(tx.tx_power_dbm);
+                RxMetadata {
+                    payload: tx.payload.clone(),
+                    rssi,
+                    snr: self.compute_snr(rssi),
+                    sf: tx.sf,
+                    frequency: tx.frequency,
+                    time: tx.end,
+                }
             })
             .collect()
     }
@@ -736,8 +739,16 @@ mod tests {
         let lora_rx = ch_lora.deliver_to(60_000);
         let strict_rx = ch_strict.deliver_to(60_000);
 
-        assert_eq!(lora_rx.len(), 1, "LoRa threshold=6: strong signal must survive");
-        assert_eq!(strict_rx.len(), 0, "strict threshold=10: both collide at delta=6");
+        assert_eq!(
+            lora_rx.len(),
+            1,
+            "LoRa threshold=6: strong signal must survive"
+        );
+        assert_eq!(
+            strict_rx.len(),
+            0,
+            "strict threshold=10: both collide at delta=6"
+        );
     }
 
     proptest! {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -224,23 +224,20 @@ impl Scheduler {
                     self.metrics.record_capture();
                 }
                 let mut wakes = Vec::new();
+                let mut tx_node_idxs = Vec::new();
                 for i in 0..self.nodes.len() {
                     if self.nodes[i].node_id() != sender {
+                        let node_id = self.nodes[i].node_id();
                         let next = self.nodes[i].on_receive(frame.clone(), time);
-                        self.metrics.record_rx(self.nodes[i].node_id());
+                        self.metrics.record_rx(node_id);
                         if let Some(t) = next {
-                            wakes.push((self.nodes[i].node_id(), t));
+                            wakes.push((node_id, t));
                         }
+                        tx_node_idxs.push(i);
                     }
                 }
                 for (node_id, t) in wakes {
                     self.schedule(t, EventKind::Wake { node_id });
-                }
-                let mut tx_node_idxs = Vec::new();
-                for i in 0..self.nodes.len() {
-                    if self.nodes[i].node_id() != sender {
-                        tx_node_idxs.push(i);
-                    }
                 }
                 for i in tx_node_idxs {
                     self.handle_poll_transmit(i, time);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
-use crate::channel::{Channel, ChannelConfig, CompletedTx};
+use crate::channel::{Channel, CompletedTx};
 use crate::metrics::MetricsCollector;
 use crate::time::SimTime;
 use crate::traits::InterferenceSource;

--- a/tests/aloha.rs
+++ b/tests/aloha.rs
@@ -329,15 +329,16 @@ fn capture_effect_recorded_in_metrics() {
     // The captured frame is delivered to all non-sender nodes: the weak sender
     // (NodeId(2)) and the receiver (NodeId(99)) — consistent with how the
     // scheduler delivers any successful TX to every non-sender node.
-    assert_eq!(sched.metrics.total_captures, 1, "expected one capture event");
     assert_eq!(
-        sched.metrics.total_collisions,
-        1,
+        sched.metrics.total_captures, 1,
+        "expected one capture event"
+    );
+    assert_eq!(
+        sched.metrics.total_collisions, 1,
         "weak sender should be marked collided"
     );
     assert_eq!(
-        sched.metrics.total_rx,
-        2,
+        sched.metrics.total_rx, 2,
         "captured frame delivered to 2 non-sender nodes (weak sender + receiver)"
     );
 }

--- a/tests/core_coverage.rs
+++ b/tests/core_coverage.rs
@@ -247,8 +247,14 @@ fn channel_late_strong_captures_earlier_weak() {
     ch.resolve_at(80_000);
     let completed = ch.drain_completed();
 
-    let strong_entry = completed.iter().find(|(id, _, _, _)| *id == NodeId(2)).unwrap();
-    let weak_entry = completed.iter().find(|(id, _, _, _)| *id == NodeId(1)).unwrap();
+    let strong_entry = completed
+        .iter()
+        .find(|(id, _, _, _)| *id == NodeId(2))
+        .unwrap();
+    let weak_entry = completed
+        .iter()
+        .find(|(id, _, _, _)| *id == NodeId(1))
+        .unwrap();
     assert!(!strong_entry.1, "strong signal should not be collided");
     assert!(strong_entry.2, "strong signal should be captured");
     assert!(weak_entry.1, "weak signal should be collided");
@@ -401,7 +407,10 @@ fn scheduler_multi_hop_reply_chain() {
     sched.run();
 
     assert_eq!(sched.metrics.total_tx, 2, "original + reply");
-    assert_eq!(sched.metrics.total_rx, 2, "each node receives the other's TX");
+    assert_eq!(
+        sched.metrics.total_rx, 2,
+        "each node receives the other's TX"
+    );
 }
 
 #[test]
@@ -448,7 +457,10 @@ fn scheduler_interferer_and_node_different_sf_no_collision() {
     // Node 1 TX (SF7) -> delivered to Node 2 (1 RX)
     // Interferer TX (SF12) -> delivered to Node 1 and Node 2 (2 RX)
     // Total: 3 RX
-    assert_eq!(sched.metrics.total_rx, 3, "node TX + interferer TX delivered on different SFs");
+    assert_eq!(
+        sched.metrics.total_rx, 3,
+        "node TX + interferer TX delivered on different SFs"
+    );
 }
 
 #[test]

--- a/tests/protocol_contract.rs
+++ b/tests/protocol_contract.rs
@@ -26,20 +26,11 @@ impl Protocol for MinimalProtocol {
         (MinimalState { transmitted: false }, Some(0))
     }
 
-    fn on_receive(
-        &self,
-        _state: &mut MinimalState,
-        _frame: RxMetadata,
-        _time: u64,
-    ) -> Option<u64> {
+    fn on_receive(&self, _state: &mut MinimalState, _frame: RxMetadata, _time: u64) -> Option<u64> {
         None
     }
 
-    fn poll_transmit(
-        &self,
-        state: &mut MinimalState,
-        _time: u64,
-    ) -> Option<Transmission> {
+    fn poll_transmit(&self, state: &mut MinimalState, _time: u64) -> Option<Transmission> {
         if state.transmitted {
             return None;
         }

--- a/tests/protocol_timer_contract.rs
+++ b/tests/protocol_timer_contract.rs
@@ -18,91 +18,6 @@ use theatron::traits::Protocol;
 use theatron::types::{NodeId, RxMetadata, Transmission};
 
 // ---------------------------------------------------------------------------
-// TwoPhaseProtocol — a minimal Protocol implementation used by the tests
-// ---------------------------------------------------------------------------
-
-/// A two-phase protocol that:
-///
-/// 1. At t = 0 transmits one beacon frame and asks to be woken at t = 1_000_000.
-/// 2. At t = 1_000_000 records the exact wake time so the test can assert it.
-///
-/// This is intentionally the smallest possible `Protocol` that exercises both
-/// the transmit path and the deferred-wake (timer) path.
-struct TwoPhaseProtocol;
-
-struct TwoPhaseState {
-    /// Set to `true` once `update` has been called at the RX-window time.
-    rx_window_fired: bool,
-    /// The `SimTime` value passed to the second `update` call (the RX window).
-    rx_window_time: Option<SimTime>,
-    /// Number of frames queued for transmission by `poll_transmit`.
-    transmit_count: u32,
-}
-
-impl Protocol for TwoPhaseProtocol {
-    type Config = ();
-    type State = TwoPhaseState;
-    type Metrics = u32; // returns the transmit count
-
-    fn init(&self, _config: ()) -> (TwoPhaseState, Option<SimTime>) {
-        let state = TwoPhaseState {
-            rx_window_fired: false,
-            rx_window_time: None,
-            transmit_count: 0,
-        };
-        // Wake immediately at t = 0 so `update` → `poll_transmit` fires.
-        (state, Some(0))
-    }
-
-    fn on_receive(
-        &self,
-        _state: &mut TwoPhaseState,
-        _frame: RxMetadata,
-        _time: SimTime,
-    ) -> Option<SimTime> {
-        None
-    }
-
-    fn poll_transmit(
-        &self,
-        state: &mut TwoPhaseState,
-        _time: SimTime,
-    ) -> Option<Transmission> {
-        // Emit exactly one beacon frame the first time we are polled.
-        if state.transmit_count == 0 {
-            state.transmit_count += 1;
-            Some(Transmission {
-                payload: vec![0xBE, 0xAC, 0x04],
-                sf: 7,
-                bandwidth: 125_000,
-                coding_rate: 5,
-                frequency: 868_100_000,
-                duration_us: 50_000,
-                tx_power_dbm: 14,
-            })
-        } else {
-            None
-        }
-    }
-
-    fn update(&self, state: &mut TwoPhaseState, time: SimTime) -> Option<SimTime> {
-        if !state.rx_window_fired {
-            // Phase 1 — initial wake.  Schedule the RX window.
-            state.rx_window_fired = true;
-            Some(1_000_000)
-        } else {
-            // Phase 2 — RX-window wake.  Record the exact time for assertion.
-            state.rx_window_time = Some(time);
-            None // no further wakes
-        }
-    }
-
-    fn metrics(&self, state: &TwoPhaseState) -> u32 {
-        state.transmit_count
-    }
-}
-
-// ---------------------------------------------------------------------------
 // ProtocolNode — bridges Protocol + State into NodeHandle
 // ---------------------------------------------------------------------------
 
@@ -123,7 +38,14 @@ impl<P: Protocol> ProtocolNode<P> {
     /// `Scheduler::add_node`.
     fn new(id: NodeId, protocol: P, config: P::Config) -> (Self, Option<SimTime>) {
         let (state, wake) = protocol.init(config);
-        (Self { id, protocol, state }, wake)
+        (
+            Self {
+                id,
+                protocol,
+                state,
+            },
+            wake,
+        )
     }
 }
 
@@ -159,26 +81,10 @@ where
 fn scheduler_delivers_wake_at_exact_scheduled_time() {
     const RX_WINDOW: SimTime = 1_000_000;
 
-    let (node, initial_wake) = ProtocolNode::new(NodeId(1), TwoPhaseProtocol, ());
-    // Downcast to Box<dyn NodeHandle> — we need to keep a raw pointer so we can
-    // inspect state after the run.  Instead, we run the scheduler and then query
-    // the metrics (which encode the transmit count).  The wake-time assertion is
-    // encoded in the protocol state; we recover it through a second, post-run
-    // `ProtocolNode` that we build just for introspection.
-    //
-    // Simpler approach: use a shared-state wrapper via a raw pointer that is
-    // valid for the duration of the test.  But the cleanest approach for this
-    // codebase is to keep everything owned.  We therefore use a two-node setup
-    // where one node records the observation and we extract it from `metrics`.
-    //
-    // Actually the cleanest approach: keep the `ProtocolNode` in a `Box`, run
-    // the scheduler, and downcast back.  `Box<dyn NodeHandle>` doesn't support
-    // downcasting, so we'll use `unsafe` pointer aliasing to peek at state.
-    //
-    // The simplest correct approach: use `std::rc::Rc<RefCell<…>>` for shared
-    // state.  We go with that to keep things readable.
-
-    // Re-implement with shared state so we can observe after the run.
+    // Use `Rc<RefCell<…>>` for shared state so the test body can observe the
+    // protocol's behaviour after the scheduler has run.  A `Box<dyn NodeHandle>`
+    // handed to the scheduler cannot be downcast, so shared state is the
+    // cleanest way to inspect wake-time observations post-run.
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -244,7 +150,9 @@ fn scheduler_delivers_wake_at_exact_scheduled_time() {
         transmit_count: 0,
     }));
 
-    let protocol = ObservingProtocol { shared: Rc::clone(&shared) };
+    let protocol = ObservingProtocol {
+        shared: Rc::clone(&shared),
+    };
     let (node, initial_wake) = ProtocolNode::new(NodeId(1), protocol, ());
 
     let mut sched = Scheduler::new(2_000_000);
@@ -271,8 +179,7 @@ fn scheduler_delivers_wake_at_exact_scheduled_time() {
 
     // --- Transmission count: exactly one frame was sent ---
     assert_eq!(
-        sched.metrics.total_tx,
-        1,
+        sched.metrics.total_tx, 1,
         "expected exactly 1 transmission, got {}",
         sched.metrics.total_tx,
     );
@@ -349,7 +256,9 @@ fn protocol_init_wake_at_zero_fires_update() {
 
     let (node, initial_wake) = ProtocolNode::new(
         NodeId(3),
-        WakeAtZeroProtocol { flag: Rc::clone(&update_called) },
+        WakeAtZeroProtocol {
+            flag: Rc::clone(&update_called),
+        },
         (),
     );
 
@@ -361,22 +270,4 @@ fn protocol_init_wake_at_zero_fires_update() {
         *update_called.borrow(),
         "update was never called even though init returned Some(0)"
     );
-}
-
-/// Guard against `src/main.rs` — that file's `main_does_not_panic` test is a
-/// trivial stub that adds no value.  This test documents the issue so it is not
-/// forgotten.  Once `src/main.rs` is removed the binary target and this comment
-/// can be removed as well.
-///
-/// See PR body for the recommended follow-up action.
-#[test]
-fn main_binary_is_noop_and_should_be_removed() {
-    // This test exists only as documentation.  The real assertion is in the PR
-    // body: src/main.rs contains a trivial `println!` and a `main_does_not_panic`
-    // test that provides zero coverage.  It should be deleted along with the
-    // [[bin]] entry in Cargo.toml once the project no longer needs a binary
-    // target.
-    //
-    // Nothing to assert here — the test passes unconditionally to flag the issue
-    // without causing a build failure.
 }

--- a/tests/scheduler_ordering.rs
+++ b/tests/scheduler_ordering.rs
@@ -180,7 +180,11 @@ fn wake_past_end_time_is_dropped() {
         "wake past end_time must never be dispatched, got {:?}",
         log.borrow(),
     );
-    assert!(sched.current_time() <= END);
+    assert_eq!(
+        sched.current_time(),
+        0,
+        "scheduler must not advance time when the only event is past end_time",
+    );
 }
 
 /// An interferer whose first poll is past `end_time` must not inject.

--- a/tests/scheduler_ordering.rs
+++ b/tests/scheduler_ordering.rs
@@ -1,0 +1,307 @@
+//! Scheduler ordering and termination invariants.
+//!
+//! Locks in three load-bearing guarantees of `theatron::scheduler::Scheduler`
+//! that were only indirectly exercised before:
+//!
+//! 1. FIFO among simultaneous events (the `seq` tiebreaker in
+//!    `ScheduledEvent::cmp`) — the foundation of the project's determinism
+//!    promise. `BinaryHeap`'s internal tiebreaking is not guaranteed by std,
+//!    so without the tiebreaker `Scheduler::run` would be order-dependent.
+//!
+//! 2. `end_time` boundary inclusivity — the run loop breaks on
+//!    `event.time > end_time`, so a wake at exactly `end_time` must fire
+//!    while a wake one tick past must not.
+//!
+//! 3. Broadcast receiver-visit order stability — `deliver_completed_to_nodes`
+//!    iterates `self.nodes` in registration order; if someone ever swaps the
+//!    `Vec` for a `HashMap`, deterministic replays would silently break.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use theatron::scheduler::{NodeHandle, Scheduler};
+use theatron::time::SimTime;
+use theatron::traits::InterferenceSource;
+use theatron::types::{ChannelEvent, NodeId, RxMetadata, Transmission};
+
+fn tx(payload: Vec<u8>) -> Transmission {
+    Transmission {
+        payload,
+        sf: 7,
+        bandwidth: 125_000,
+        coding_rate: 5,
+        frequency: 868_100_000,
+        duration_us: 50_000,
+        tx_power_dbm: 14,
+    }
+}
+
+/// Records its wake time and receive order into shared logs.
+struct LoggingNode {
+    id: NodeId,
+    log: Rc<RefCell<Vec<(NodeId, SimTime)>>>,
+    pending_tx: Option<Transmission>,
+    pending_rx: Rc<RefCell<Vec<NodeId>>>,
+}
+
+impl LoggingNode {
+    fn new(
+        id: u32,
+        log: Rc<RefCell<Vec<(NodeId, SimTime)>>>,
+        pending_tx: Option<Transmission>,
+        pending_rx: Rc<RefCell<Vec<NodeId>>>,
+    ) -> Self {
+        Self {
+            id: NodeId(id),
+            log,
+            pending_tx,
+            pending_rx,
+        }
+    }
+}
+
+impl NodeHandle for LoggingNode {
+    fn node_id(&self) -> NodeId {
+        self.id
+    }
+    fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
+        self.pending_rx.borrow_mut().push(self.id);
+        None
+    }
+    fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
+        self.pending_tx.take()
+    }
+    fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        self.log.borrow_mut().push((self.id, time));
+        None
+    }
+}
+
+// --- Invariant 1: FIFO among simultaneous wake events ---
+
+/// Nodes registered with the same initial wake time fire their `update`
+/// callbacks in registration order.
+#[test]
+fn simultaneous_wakes_fire_in_insertion_order() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let sink = Rc::new(RefCell::new(Vec::new()));
+
+    let mut sched = Scheduler::new(100_000);
+    for id in [5u32, 1, 42, 7, 3] {
+        sched.add_node(
+            Box::new(LoggingNode::new(
+                id,
+                Rc::clone(&log),
+                None,
+                Rc::clone(&sink),
+            )),
+            Some(0),
+        );
+    }
+    sched.run();
+
+    let observed: Vec<NodeId> = log.borrow().iter().map(|(id, _)| *id).collect();
+    assert_eq!(
+        observed,
+        vec![NodeId(5), NodeId(1), NodeId(42), NodeId(7), NodeId(3)],
+        "simultaneous wakes must fire in registration order for determinism",
+    );
+    assert!(log.borrow().iter().all(|(_, t)| *t == 0));
+}
+
+/// Two runs of the same scenario produce identical event sequences.
+#[test]
+fn run_is_bitwise_deterministic_across_runs() {
+    fn run_once() -> Vec<(NodeId, SimTime)> {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let sink = Rc::new(RefCell::new(Vec::new()));
+        let mut sched = Scheduler::new(500_000);
+        for id in [10u32, 20, 30] {
+            sched.add_node(
+                Box::new(LoggingNode::new(
+                    id,
+                    Rc::clone(&log),
+                    None,
+                    Rc::clone(&sink),
+                )),
+                Some(100_000),
+            );
+        }
+        sched.run();
+        log.borrow().clone()
+    }
+
+    assert_eq!(
+        run_once(),
+        run_once(),
+        "scheduler must be deterministic run-to-run",
+    );
+}
+
+// --- Invariant 2: end_time boundary is inclusive ---
+
+/// A wake at exactly `end_time` must still be dispatched.
+#[test]
+fn wake_at_exact_end_time_fires() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let sink = Rc::new(RefCell::new(Vec::new()));
+    const END: SimTime = 250_000;
+
+    let mut sched = Scheduler::new(END);
+    sched.add_node(
+        Box::new(LoggingNode::new(1, Rc::clone(&log), None, Rc::clone(&sink))),
+        Some(END),
+    );
+    sched.run();
+
+    assert_eq!(
+        *log.borrow(),
+        vec![(NodeId(1), END)],
+        "wake at exactly end_time must fire (loop breaks on `>`, not `>=`)",
+    );
+}
+
+/// A wake one microsecond past `end_time` must not be dispatched.
+#[test]
+fn wake_past_end_time_is_dropped() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let sink = Rc::new(RefCell::new(Vec::new()));
+    const END: SimTime = 250_000;
+
+    let mut sched = Scheduler::new(END);
+    sched.add_node(
+        Box::new(LoggingNode::new(1, Rc::clone(&log), None, Rc::clone(&sink))),
+        Some(END + 1),
+    );
+    sched.run();
+
+    assert!(
+        log.borrow().is_empty(),
+        "wake past end_time must never be dispatched, got {:?}",
+        log.borrow(),
+    );
+    assert!(sched.current_time() <= END);
+}
+
+/// An interferer whose first poll is past `end_time` must not inject.
+#[test]
+fn interferer_first_poll_past_end_time_is_dropped() {
+    struct TrackingInterferer {
+        injected: Rc<RefCell<u32>>,
+    }
+    impl InterferenceSource for TrackingInterferer {
+        fn observe(&mut self, _: &ChannelEvent, _: SimTime) {}
+        fn poll_inject(&mut self, _: SimTime) -> Option<Transmission> {
+            *self.injected.borrow_mut() += 1;
+            None
+        }
+        fn next_poll_time(&self, _: SimTime) -> Option<SimTime> {
+            None
+        }
+    }
+
+    let injected = Rc::new(RefCell::new(0u32));
+    let mut sched = Scheduler::new(100_000);
+    sched.add_interferer(
+        Box::new(TrackingInterferer {
+            injected: Rc::clone(&injected),
+        }),
+        100_001,
+    );
+    sched.run();
+
+    assert_eq!(
+        *injected.borrow(),
+        0,
+        "interferer past end_time must not be polled",
+    );
+}
+
+// --- Invariant 3: broadcast receiver-visit order is stable ---
+
+/// A single TX delivered to multiple receivers visits them in
+/// registration order.
+#[test]
+fn broadcast_delivers_in_registration_order() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let rx_order = Rc::new(RefCell::new(Vec::new()));
+
+    let mut sched = Scheduler::new(200_000);
+
+    sched.add_node(
+        Box::new(LoggingNode::new(
+            0,
+            Rc::clone(&log),
+            Some(tx(vec![0xAA])),
+            Rc::clone(&rx_order),
+        )),
+        Some(0),
+    );
+
+    for id in [50u32, 3, 17, 99, 2] {
+        sched.add_node(
+            Box::new(LoggingNode::new(
+                id,
+                Rc::clone(&log),
+                None,
+                Rc::clone(&rx_order),
+            )),
+            None,
+        );
+    }
+    sched.run();
+
+    assert_eq!(
+        *rx_order.borrow(),
+        vec![NodeId(50), NodeId(3), NodeId(17), NodeId(99), NodeId(2)],
+        "broadcast must visit receivers in registration order",
+    );
+    assert_eq!(sched.metrics.total_rx, 5);
+}
+
+// --- Invariant 4: self-rescheduling stops at end_time ---
+
+/// A periodic node stops firing exactly at `end_time`.
+#[test]
+fn periodic_wake_stops_at_end_time_boundary() {
+    struct PeriodicLogger {
+        id: NodeId,
+        period: SimTime,
+        log: Rc<RefCell<Vec<SimTime>>>,
+    }
+    impl NodeHandle for PeriodicLogger {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _: RxMetadata, _: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&mut self, _: SimTime) -> Option<Transmission> {
+            None
+        }
+        fn update(&mut self, t: SimTime) -> Option<SimTime> {
+            self.log.borrow_mut().push(t);
+            Some(t + self.period)
+        }
+    }
+
+    const END: SimTime = 300_000;
+    const PERIOD: SimTime = 100_000;
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let mut sched = Scheduler::new(END);
+    sched.add_node(
+        Box::new(PeriodicLogger {
+            id: NodeId(1),
+            period: PERIOD,
+            log: Rc::clone(&log),
+        }),
+        Some(0),
+    );
+    sched.run();
+
+    assert_eq!(
+        *log.borrow(),
+        vec![0, 100_000, 200_000, 300_000],
+        "periodic wakes must fire at every multiple <= end_time and stop past it",
+    );
+}


### PR DESCRIPTION
## Component

`src/scheduler.rs` — the `Scheduler` event loop, specifically the FIFO tiebreaker inside `ScheduledEvent::cmp` and the `event.time > end_time` termination check in `Scheduler::run`.

## Current disposition

Before this PR, `tests/core_coverage.rs::scheduler_determinism` was the only indirect probe of run-to-run reproducibility (metrics-level, a single scenario), and the `end_time` boundary was only exercised with `<= end_time` scenarios. No test asserted:

- simultaneous events fire in insertion order — the `seq` tiebreaker is load-bearing because `std::collections::BinaryHeap` does not document stable ordering;
- a wake at exactly `end_time` fires (`>` vs `>=` off-by-one);
- a wake one tick past `end_time` is dropped;
- `add_interferer(…, first_poll = end_time + 1)` correctly drops the poll;
- broadcast delivery visits receivers in registration order (required for determinism if `self.nodes` ever changes representation);
- self-rescheduling periodic nodes halt exactly at the boundary.

Any of these regressing would silently corrupt the project's determinism promise (called out in ARCHITECTURE.md as foundational) without triggering a test failure.

## Invariants under test

1. **FIFO among simultaneous events**: events scheduled with equal `SimTime` fire in push order (via `seq`).
2. **Run-to-run determinism**: identical inputs produce bitwise-identical event traces.
3. **`end_time` boundary inclusivity**: loop breaks on `>`, so `event.time == end_time` fires; `event.time == end_time + 1` does not.
4. **Interferer termination**: an interferer whose `first_poll > end_time` never has `poll_inject` called.
5. **Broadcast receiver-visit order**: `deliver_completed_to_nodes` calls `on_receive` on registered nodes in order.
6. **Periodic termination**: a node returning `Some(t + period)` from `update` fires at every multiple `<= end_time` and stops.

## Strategy and why

**Strategy**: integration tests in `tests/scheduler_ordering.rs` using `Rc<RefCell<Vec<_>>>` probes attached to custom `NodeHandle` / `InterferenceSource` implementations to capture the exact sequence of scheduler callbacks.

**Why not proptest**: the invariants are deterministic boolean predicates about event ordering at specific timestamps — concrete small cases are more expressive, debuggable, and cheaper than randomized ones. Generating valid interleaved scenarios would also require modeling the scheduler's state machine in the generator, duplicating the thing under test.

**Why not unit tests in `src/scheduler.rs`**: the assertions are about observable behaviour of the public API (`Scheduler::run`, `add_node`, `add_interferer`), so integration scope is right and demonstrates what external users actually depend on. Tests also serve as executable documentation for invariants not spelled out inline in the scheduler source.

## Also: dead-code debloat (commit 54876e6)

- `tests/protocol_timer_contract.rs`: `TwoPhaseProtocol`/`TwoPhaseState` (~85 lines) were defined but the one test that instantiated them immediately shadowed the binding and used an inline `ObservingProtocol` with `Rc<RefCell<_>>` shared state instead — all dead code removed. The same test had ~15 lines of decision-narrative comments ("Simpler approach:", "Actually the cleanest approach:", ...) documenting abandoned designs; replaced with a 4-line rationale for the chosen approach. `main_binary_is_noop_and_should_be_removed` was a no-op test whose body was only a comment about another file — the observation belongs in a PR body.
- `src/scheduler.rs`: drop unused `ChannelConfig` import (the tests module re-imports locally).
- `src/channel.rs::Channel::deliver_to` computed `compute_rssi` twice per element; cached once and passed to `compute_snr`.
- `examples/lorawan_file_transfer/simulated_radio.rs`: move `Bandwidth`/`CodingRate`/`SpreadingFactor` imports into `mod tests` since top-level code only needs `BaseBandModulationParams`.

## Test plan

- [x] `cargo test --all-features` — all suites pass (new `scheduler_ordering` suite: 7 tests)
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] pre-commit hooks (fmt, clippy, test, coverage, security review) pass; `audit`/`deny` skipped due to missing binaries in the sandbox only

https://claude.ai/code/session_017vrZ4D421Ty4uKSgmm7Qsb