### PR TITLE
[clarity] README: add navigation pointers and relative cross-doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 [![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
-[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron/blob/main/LICENSE-MIT)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](#license)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
 
-Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.
+Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects (propagation, interference, contention, adversarial scenarios). LoRaWAN via lora-rs is the first validation target.
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — design, core abstractions, phased roadmap.
+
+## Examples
+
+- [`examples/aloha`](examples/aloha) — Pure ALOHA reference protocol.
+- [`examples/lorawan_file_transfer`](examples/lorawan_file_transfer) — LoRaWAN Class A via `lorawan-device`, with a simulated radio and network server.
+
+Run an example:
+
+```sh
+cargo run --example aloha
+cargo run --example lorawan_file_transfer
+```
+
+## License
+
+Dual-licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.


### PR DESCRIPTION
## Cluster: format standardization (relative cross-doc links + navigation)

The current `README.md` is a single-line description with badges. It does not point to `ARCHITECTURE.md`, the two runnable examples, or the dual-license files — readers landing from crates.io or GitHub have to grep the tree to find them.

### What is tightened
- Adds a short Documentation section with a relative link to [`ARCHITECTURE.md`](../blob/claude/awesome-hawking-5ajrK/ARCHITECTURE.md).
- Adds an Examples section with relative paths to `examples/aloha` and `examples/lorawan_file_transfer` plus the `cargo run --example` invocations.
- Wires the license badge to an in-page anchor and adds a License section linking the dual-license files via relative paths (`LICENSE-APACHE`, `LICENSE-MIT`).
- Tightens the project tagline by absorbing the parenthetical from `ARCHITECTURE.md`'s opening paragraph (no new claims).

### What is skipped
- `ARCHITECTURE.md` rewrites — already covered by sibling clarity PRs (#45, #48, #49, #50).
- Source-file doc-comment cleanup — already covered by #49.
- No emoji, no fluff, no new sections beyond pointers.

### Scope
- 1 file changed (`README.md`).
- No code or behavior changes; doc-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_