### PR TITLE
clarity(theatron): remove stale code sketches, what-comments, and inconsistent headings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,121 +107,30 @@ The scheduler calls `poll_transmit` on the protocol; the protocol (or its adapte
 
 LoRaWAN via lora-rs is the first real-world protocol used to prove the simulation engine works with a real stack. The validation example is external to theatron core and comprises three components:
 
-- **LoRaWAN device adapter**: wraps `lorawan-device::nb_device` to implement the `Protocol` trait
-- **Simulated network server**: responds to joins and schedules downlinks (see below)
-- **SimulatedRadio**: bridges the adapter to theatron's channel
+- **LoRaWAN device adapter**: wraps `lorawan-device::nb_device` to implement the `Protocol` trait (see [`examples/lorawan_file_transfer/lorawan_adapter.rs`](examples/lorawan_file_transfer/lorawan_adapter.rs))
+- **Simulated network server**: responds to joins and schedules downlinks (see [`examples/lorawan_file_transfer/network_server.rs`](examples/lorawan_file_transfer/network_server.rs))
+- **SimulatedRadio**: bridges the adapter to theatron's channel (see [`examples/lorawan_file_transfer/simulated_radio.rs`](examples/lorawan_file_transfer/simulated_radio.rs))
 
 The validation example uses:
 
 - **`lorawan`**: frame parsing and creation, MIC verification, MAC command handling. `RxMetadata.payload` and `Transmission.payload` are raw bytes parsed via `lorawan::parser::PhyPayload`.
-- **`lorawan-device`**: real Class A state machine via `nb_device`. The adapter drives it by implementing `lorawan_device::nb_device::radio::PhyRxTx` on a `SimulatedRadio` struct that bridges to the simulated channel.
+- **`lorawan-device`**: real Class A state machine via `nb_device`. The adapter drives it by implementing `lorawan_device::nb_device::radio::PhyRxTx` on `SimulatedRadio`, which bridges to the simulated channel.
 - **`lora-modulation`**: SF, bandwidth, and time-on-air calculations. Used in the channel model and energy-efficiency metrics.
 
-#### `nb_device::radio::PhyRxTx` — the actual interface
+#### `nb_device::radio::PhyRxTx` — the radio interface
 
-`lorawan-device`'s `nb_device` module exposes an event-driven radio trait, not a polling interface. `SimulatedRadio` implements this trait:
-
-```rust
-pub trait PhyRxTx {
-    type PhyEvent: fmt::Debug;
-    type PhyError: fmt::Debug;
-    type PhyResponse: fmt::Debug;
-
-    const ANTENNA_GAIN: i8 = 0;
-    const MAX_RADIO_POWER: u8;
-
-    fn get_mut_radio(&mut self) -> &mut Self;
-    fn get_received_packet(&mut self) -> &mut [u8];
-    fn handle_event(
-        &mut self,
-        event: radio::Event<'_, Self>,
-    ) -> Result<radio::Response<Self>, Self::PhyError>
-    where
-        Self: Sized;
-}
-```
+`lorawan-device`'s `nb_device` module exposes an event-driven radio trait. `SimulatedRadio` implements this trait; see [`examples/lorawan_file_transfer/simulated_radio.rs`](examples/lorawan_file_transfer/simulated_radio.rs) for the full implementation.
 
 Events: `TxRequest(TxConfig, &[u8])`, `RxRequest(RxConfig)`, `CancelRx`, `Phy(PhyEvent)`.
 Responses: `Idle`, `Txing`, `TxDone(ms)`, `Rxing`, `RxDone(RxQuality)`.
 
 The state machine calls `handle_event(TxRequest(...))` to initiate a transmission; the radio responds `Txing`, then on the next `Phy(...)` event responds `TxDone(timestamp_ms)`. For RX: `handle_event(RxRequest(...))` → `Rxing`, then when a frame arrives → `RxDone(quality)`, and the state machine reads bytes via `get_received_packet()`.
 
-#### SimulatedRadio sketch
-
-`SimulatedRadio` maintains an internal receive buffer and an RX-mode flag. theatron's channel pushes received frames into the buffer when the radio is in RX mode; frames arriving when the radio is not listening are dropped (physically correct behavior).
-
-```rust
-struct SimulatedRadio {
-    channel: Arc<Mutex<Channel>>,
-    node_id: NodeId,
-    rx_buf: [u8; 256],
-    rx_len: usize,
-    mode: RadioMode,
-}
-
-enum RadioMode { Idle, Txing { config: TxConfig }, Rxing { config: RxConfig } }
-
-impl PhyRxTx for SimulatedRadio {
-    type PhyEvent = SimPhyEvent;
-    type PhyError = SimRadioError;
-    type PhyResponse = SimPhyResponse;
-
-    const MAX_RADIO_POWER: u8 = 22;
-
-    fn get_mut_radio(&mut self) -> &mut Self { self }
-
-    fn get_received_packet(&mut self) -> &mut [u8] {
-        &mut self.rx_buf[..self.rx_len]
-    }
-
-    fn handle_event(
-        &mut self,
-        event: radio::Event<'_, Self>,
-    ) -> Result<radio::Response<Self>, Self::PhyError> {
-        match event {
-            radio::Event::TxRequest(config, buf) => {
-                self.mode = RadioMode::Txing { config };
-                self.channel.lock().unwrap().enqueue_tx(self.node_id, config, buf);
-                Ok(radio::Response::Txing)
-            }
-            radio::Event::RxRequest(config) => {
-                self.mode = RadioMode::Rxing { config };
-                Ok(radio::Response::Rxing)
-            }
-            radio::Event::CancelRx => {
-                self.mode = RadioMode::Idle;
-                Ok(radio::Response::Idle)
-            }
-            radio::Event::Phy(SimPhyEvent::TxDone { timestamp_ms }) => {
-                self.mode = RadioMode::Idle;
-                Ok(radio::Response::TxDone(timestamp_ms))
-            }
-            radio::Event::Phy(SimPhyEvent::RxDone { quality, payload }) => {
-                self.rx_len = payload.len().min(self.rx_buf.len());
-                self.rx_buf[..self.rx_len].copy_from_slice(&payload[..self.rx_len]);
-                self.mode = RadioMode::Idle;
-                Ok(radio::Response::RxDone(quality))
-            }
-        }
-    }
-}
-```
-
-The `lorawan-device` state machine calls `handle_event` on `SimulatedRadio`; theatron's scheduler delivers simulated radio events (TX completion, RX frame arrival) by calling `device.handle_event(Event::RadioEvent(phy_event))` on the adapter state.
-
 #### Adapter state ownership
 
-`lorawan-device::nb_device::Device<R, RNG, N, D>` bundles the radio, RNG, and MAC state into a single struct. The adapter's `Protocol::State` wraps it along with bookkeeping theatron needs:
+`lorawan-device::nb_device::Device<R, RNG, N, D>` bundles the radio, RNG, and MAC state into a single struct. The adapter's state wraps it along with bookkeeping theatron needs; see [`examples/lorawan_file_transfer/lorawan_adapter.rs`](examples/lorawan_file_transfer/lorawan_adapter.rs) for the current implementation.
 
-```rust
-struct LorawanState {
-    device: nb_device::Device<SimulatedRadio, Prng, 256, 1>,
-    pending_tx: Option<Transmission>,
-    next_wake: Option<SimTime>,
-}
-```
-
-`pending_tx` is populated when the device issues a `TxRequest` through `SimulatedRadio::handle_event`. `next_wake` is updated from `nb_device::Response::TimeoutRequest(ms)` and returned from the adapter's `Protocol` methods as `Option<SimTime>`. Since `device` is inside `&mut LorawanState`, mutable access flows correctly through all `Protocol` method signatures.
+`pending_timeout_ms` is populated when the device issues a `TxRequest` through `SimulatedRadio::handle_event`. The next wake time is updated from `nb_device::Response::TimeoutRequest(ms)` and returned from the adapter's `Protocol` methods as `Option<SimTime>`.
 
 #### Timer contract
 
@@ -312,11 +221,11 @@ To ground simulations in real-world conditions, theatron may include tooling for
 
 ## Key Design Decisions (open for discussion)
 
-### Sync vs async
+### Sync vs. async
 
 **Proposal: sync.** The simulation engine controls time explicitly — there is no benefit to async here, and async adds complexity. Each node's `poll_transmit` is called by the scheduler in deterministic order. `lorawan-device::nb_device` is the correct integration target (not `async_device`) for the same reason. Revisit if we need to model real-time wall-clock behavior.
 
-### Discrete-event vs continuous time
+### Discrete-event vs. continuous time
 
 **Proposal: discrete-event.** Wireless symbol timing (e.g. LoRa) is discrete at the physical layer. Discrete-event simulation is simpler to reason about, deterministic, and fast. Continuous time adds little value for MAC-level analysis.
 

--- a/examples/aloha/aloha_node.rs
+++ b/examples/aloha/aloha_node.rs
@@ -3,11 +3,9 @@ use theatron::time::SimTime;
 use theatron::traits::TrafficModel;
 use theatron::types::{NodeId, RxMetadata, Transmission};
 
-// Default LoRa EU868 radio parameters. `sf` and `frequency` are caller-supplied
-// (they are the primary channel / orthogonality knobs for experiments).
-const DEFAULT_BANDWIDTH_HZ: u32 = 125_000; // EU868 standard bandwidth
-const DEFAULT_CODING_RATE: u8 = 5; // 4/5 coding rate
-const DEFAULT_TX_POWER_DBM: i8 = 14; // 14 dBm, legal limit for EU868
+const DEFAULT_BANDWIDTH_HZ: u32 = 125_000;
+const DEFAULT_CODING_RATE: u8 = 5;
+const DEFAULT_TX_POWER_DBM: i8 = 14;
 
 /// Pure ALOHA node: transmits immediately when a payload is available.
 ///
@@ -52,9 +50,8 @@ impl AlohaNode {
 
     /// Returns the next wake time, or `None` if traffic is permanently exhausted.
     ///
-    /// When all packets have been sent and no new payload will ever be generated,
-    /// returning `None` stops the scheduler from rescheduling this node on the
-    /// poll interval indefinitely.
+    /// When all packets have been sent, returning `None` stops the scheduler
+    /// from rescheduling this node on the poll interval indefinitely.
     fn try_generate_tx(&mut self, time: SimTime) -> Option<SimTime> {
         if self.pending_tx.is_some() {
             return Some(time);
@@ -71,18 +68,10 @@ impl AlohaNode {
             });
             Some(time)
         } else {
-            // Check whether traffic can ever produce another payload. If the
-            // model has a fixed count and it is exhausted, stop scheduling.
-            // We probe one interval ahead; if still None at a future time, we
-            // assume exhaustion — TrafficModel::next_payload is idempotent for
-            // a depleted PeriodicTraffic (remaining == 0 always returns None).
             let future = time + self.poll_interval_us;
             if self.traffic.next_payload(future).is_none() {
-                None // traffic permanently exhausted — do not reschedule
+                None
             } else {
-                // Payload will be ready in the future; wake up and check again.
-                // (next_payload consumed the future slot, but PeriodicTraffic
-                //  re-checks time >= next_time, so calling it early is safe.)
                 Some(future)
             }
         }

--- a/examples/aloha/main.rs
+++ b/examples/aloha/main.rs
@@ -6,12 +6,11 @@ use theatron::types::NodeId;
 
 use aloha_node::{AlohaNode, AlohaReceiver, PeriodicTraffic};
 
-/// Simulation parameters.
 const NUM_SENDERS: u32 = 5;
 const PACKETS_PER_SENDER: usize = 20;
-const TX_INTERVAL_US: u64 = 2_000_000; // 2s between packets
-const POLL_INTERVAL_US: u64 = 500_000; // 500ms poll interval
-const TX_DURATION_US: u64 = 200_000; // 200ms per packet (typical LoRa SF7)
+const TX_INTERVAL_US: u64 = 2_000_000; // 2 s between packets
+const POLL_INTERVAL_US: u64 = 500_000; // 500 ms poll interval
+const TX_DURATION_US: u64 = 200_000; // 200 ms per packet (typical LoRa SF7)
 const SF: u8 = 7;
 const FREQUENCY: u32 = 868_100_000;
 const SIM_DURATION_MS: u32 = 120_000; // 2 minutes
@@ -20,13 +19,11 @@ fn main() {
     let sim_duration = ms_to_sim_time(SIM_DURATION_MS);
     let mut scheduler = Scheduler::new(sim_duration);
 
-    // Add a passive receiver (NodeId 0).
     scheduler.add_node(Box::new(AlohaReceiver::new(NodeId(0))), None);
 
-    // Add ALOHA sender nodes.
     for i in 1..=NUM_SENDERS {
         let traffic = PeriodicTraffic::new(
-            vec![i as u8; 10], // 10-byte payload tagged with sender id
+            vec![i as u8; 10], // payload byte identifies sender
             TX_INTERVAL_US,
             PACKETS_PER_SENDER,
         );
@@ -50,9 +47,8 @@ fn main() {
     let m = &scheduler.metrics;
     let expected_tx = (NUM_SENDERS as u64) * (PACKETS_PER_SENDER as u64);
 
-    // PDR: fraction of transmitted packets successfully received by the receiver
-    // (NodeId 0). Each TX can reach the receiver at most once, so the denominator
-    // is simply the number of expected transmissions.
+    // PDR denominator is expected_tx: each TX can reach NodeId(0) at most once,
+    // so collisions reduce the numerator without changing the denominator.
     let receiver_rx = m.node_rx_count(NodeId(0)) as f64;
     let pdr = if expected_tx > 0 {
         receiver_rx / expected_tx as f64


### PR DESCRIPTION
## Summary

- **ARCHITECTURE.md — replaced three stale code sketches with source pointers**: The `nb_device::radio::PhyRxTx — the actual interface` block showed a trait shape that doesn't match the real `lorawan-device` crate (wrong associated type names, missing constants). The `SimulatedRadio sketch` block showed a struct using `Arc<Mutex<Channel>>`, `RadioMode`, and `SimPhyEvent` — none of which exist in `examples/lorawan_file_transfer/simulated_radio.rs`. The `LorawanState` struct didn't match `LoRaWanAdapter` in the actual code. All three sections now point to the real source files instead of diverged pseudo-code.

- **ARCHITECTURE.md — fixed inconsistent heading punctuation in Key Design Decisions**: `### Sync vs async` and `### Discrete-event vs continuous time` were missing the separating period/dot that the other headings use; normalized to `### Sync vs. async` and `### Discrete-event vs. continuous time`.

- **`examples/aloha/aloha_node.rs` — removed what-comments on self-documenting constants**: `DEFAULT_BANDWIDTH_HZ`, `DEFAULT_CODING_RATE`, and `DEFAULT_TX_POWER_DBM` had trailing comments that restated the constant name in prose (`// EU868 standard bandwidth`, `// 4/5 coding rate`, `// 14 dBm, legal limit for EU868`). The names already carry that information.

- **`examples/aloha/aloha_node.rs` — trimmed implementation-detail comment in `try_generate_tx`**: The original comment explained `PeriodicTraffic` internals (`re-checks time >= next_time`, `remaining == 0 always returns None`) inside a generic node method that shouldn't know about a specific traffic model. Replaced with a concise statement of the contract.

- **`examples/aloha/main.rs` — removed what-comments; sharpened PDR comment**: Removed `// Add a passive receiver (NodeId 0).` and `// Add ALOHA sender nodes.` (the code is self-evident). Rephrased the PDR block comment to focus on why the denominator is `expected_tx` rather than restating what each variable is. Kept unit annotations on time constants (`// 2 s between packets` etc.) as they carry genuine context. Removed the `/// Simulation parameters.` doc-comment that was misattributed to individual `const` items.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_