### PR TITLE
refactor(theatron): remove unnecessary prng.rs re-export in lorawan example

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -8,8 +8,8 @@ use theatron::traits::TrafficModel;
 use theatron::types::{NodeId, RxMetadata, Transmission};
 
 use crate::file_fragmenter::FileFragmenter;
-use crate::prng::Xorshift64;
 use crate::simulated_radio::SimulatedRadio;
+use theatron::prng::Xorshift64;
 
 const BUF_SIZE: usize = 255;
 

--- a/examples/lorawan_file_transfer/main.rs
+++ b/examples/lorawan_file_transfer/main.rs
@@ -2,7 +2,6 @@ mod file_fragmenter;
 mod lorawan_adapter;
 mod network_server;
 mod periodic_interferer;
-mod prng;
 mod simulated_radio;
 
 use theatron::scheduler::Scheduler;

--- a/examples/lorawan_file_transfer/prng.rs
+++ b/examples/lorawan_file_transfer/prng.rs
@@ -1,2 +1,0 @@
-// Re-export from the core library to avoid duplication.
-pub use theatron::prng::Xorshift64;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Delete `examples/lorawan_file_transfer/prng.rs`, which was a 2-line file containing only `pub use theatron::prng::Xorshift64;`
- Remove `mod prng;` from `examples/lorawan_file_transfer/main.rs`
- Change the import in `examples/lorawan_file_transfer/lorawan_adapter.rs` from `use crate::prng::Xorshift64` to `use theatron::prng::Xorshift64`

The intermediate re-export module added unnecessary indirection: `lorawan_adapter.rs` was reaching `theatron::prng::Xorshift64` through a local shim instead of importing it directly from the crate that defines it.

## Test plan

- [ ] `cargo build --example lorawan_file_transfer` compiles without errors
- [ ] `cargo clippy --example lorawan_file_transfer` reports no warnings
- [ ] Confirm `prng.rs` no longer exists in `examples/lorawan_file_transfer/`
- [ ] Confirm `mod prng;` is absent from `main.rs`
- [ ] Confirm `lorawan_adapter.rs` imports `use theatron::prng::Xorshift64` directly

https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_