### PR TITLE
refactor(theatron): stage pending_tx as adapter-level field rather than lazy radio query in poll_transmit

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -20,6 +20,9 @@ pub struct LoRaWanAdapter {
     pending_timeout_ms: Option<u32>,
     tx_start_time: SimTime,
     joined: bool,
+    /// Transmission staged during `on_receive` / `update` so that
+    /// `poll_transmit` never needs to reach into the radio directly.
+    pending_tx: Option<Transmission>,
 }
 
 impl LoRaWanAdapter {
@@ -44,11 +47,21 @@ impl LoRaWanAdapter {
             pending_timeout_ms: None,
             tx_start_time: 0,
             joined: true,
+            pending_tx: None,
         }
     }
 
     fn wake_from_timeout(&self, ms: u32) -> SimTime {
         self.tx_start_time + ms as u64 * 1_000
+    }
+
+    /// Harvest any transmission that the radio has prepared and stage it
+    /// on the adapter so that `poll_transmit` can drain it without
+    /// touching the radio directly.
+    fn stage_pending_tx(&mut self) {
+        if let Some(tx) = self.device.get_radio().take_pending_tx() {
+            self.pending_tx = Some(tx);
+        }
     }
 
     fn try_send_fragment(&mut self, time: SimTime) -> Option<SimTime> {
@@ -60,9 +73,13 @@ impl LoRaWanAdapter {
             match self.device.send(&payload, 1, false) {
                 Ok(Response::TimeoutRequest(ms)) => {
                     self.pending_timeout_ms = Some(ms);
+                    self.stage_pending_tx();
                     Some(self.wake_from_timeout(ms))
                 }
-                Ok(_) => None,
+                Ok(_) => {
+                    self.stage_pending_tx();
+                    None
+                }
                 Err(_) => None,
             }
         } else {
@@ -81,11 +98,15 @@ impl NodeHandle for LoRaWanAdapter {
         if !radio.inject_downlink(frame.payload.clone(), frame.sf, frame.frequency) {
             return None;
         }
-        match self
+        let result = self
             .device
             .handle_event(lorawan_device::nb_device::Event::RadioEvent(
                 RadioEvent::Phy(()),
-            )) {
+            ));
+        // Stage any transmission the device queued onto the radio before
+        // returning, so poll_transmit only needs to drain the adapter field.
+        self.stage_pending_tx();
+        match result {
             Ok(Response::TimeoutRequest(ms)) => {
                 self.pending_timeout_ms = Some(ms);
                 Some(self.wake_from_timeout(ms))
@@ -100,15 +121,18 @@ impl NodeHandle for LoRaWanAdapter {
     }
 
     fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
-        self.device.get_radio().take_pending_tx()
+        self.pending_tx.take()
     }
 
     fn update(&mut self, time: SimTime) -> Option<SimTime> {
         if let Some(_timeout_ms) = self.pending_timeout_ms.take() {
-            match self
+            let result = self
                 .device
-                .handle_event(lorawan_device::nb_device::Event::TimeoutFired)
-            {
+                .handle_event(lorawan_device::nb_device::Event::TimeoutFired);
+            // Stage any transmission produced by the timeout event before
+            // inspecting the response variant.
+            self.stage_pending_tx();
+            match result {
                 Ok(Response::TimeoutRequest(ms)) => {
                     self.pending_timeout_ms = Some(ms);
                     Some(self.wake_from_timeout(ms))


### PR DESCRIPTION
## Summary

- Adds `pending_tx: Option<Transmission>` field to `LoRaWanAdapter` so the adapter owns the lifecycle of any outbound transmission.
- Introduces a private `stage_pending_tx` helper that calls `self.device.get_radio().take_pending_tx()` and stores the result; this helper is invoked at the end of every device-event call site inside `on_receive`, `update`, and `try_send_fragment`.
- `poll_transmit` now simply calls `self.pending_tx.take()` — the radio layer is never touched from the poll path.

## Motivation

Previously `poll_transmit` reached directly into the radio every time it was called:

```rust
fn poll_transmit(&mut self, _time: SimTime) -> Option<Transmission> {
    self.device.get_radio().take_pending_tx()
}
```

This created an implicit coupling: the caller had to know that the radio might hold a transmission *at any point*, not just right after the adapter processed a device event. Centralising the harvest into the event-processing sites makes the data flow explicit and keeps `poll_transmit` a pure drain of adapter state.

## Test plan

- [ ] Verify the example compiles: `cargo build --example lorawan_file_transfer`
- [ ] Run the existing test suite: `cargo test`
- [ ] Confirm that `poll_transmit` returns the expected transmission after `on_receive` and `update` calls in integration/simulation runs


---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_