### PR TITLE
feat(theatron): implement per-node PRNG seed derivation from master seed in lorawan_adapter

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -13,6 +13,24 @@ use crate::simulated_radio::SimulatedRadio;
 
 const BUF_SIZE: usize = 255;
 
+/// Derive a per-node PRNG seed from a master seed and a node identifier.
+///
+/// Mixing uses a Knuth multiplicative hash step so that every `(master_seed,
+/// node_id)` pair produces a distinct, well-distributed seed:
+///
+/// ```text
+/// per_node_seed = master_seed ^ (node_id.wrapping_mul(0x9e3779b97f4a7c15))
+/// ```
+///
+/// The constant `0x9e3779b97f4a7c15` is the 64-bit fractional part of the
+/// golden ratio, a standard choice for Fibonacci hashing.  XOR-ing it with
+/// the master seed ensures that two nodes with `node_id = 0` and
+/// `node_id = 1` receive seeds that differ by more than one bit flip, making
+/// simulations reproducible and per-node sequences independent.
+pub fn derive_seed(master_seed: u64, node_id: u64) -> u64 {
+    master_seed ^ node_id.wrapping_mul(0x9e3779b97f4a7c15)
+}
+
 pub struct LoRaWanAdapter {
     id: NodeId,
     device: Device<SimulatedRadio, Xorshift64, BUF_SIZE>,
@@ -23,7 +41,14 @@ pub struct LoRaWanAdapter {
 }
 
 impl LoRaWanAdapter {
-    pub fn new(id: NodeId, fragmenter: FileFragmenter, seed: u64) -> Self {
+    /// Create a new adapter for `id`.
+    ///
+    /// The RNG seed used internally is **derived** from `master_seed` and the
+    /// numeric value of `node_id` via [`derive_seed`], so each node in a
+    /// multi-node simulation gets an independent, reproducible PRNG stream
+    /// while the caller only needs to track a single master seed constant.
+    pub fn new(id: NodeId, fragmenter: FileFragmenter, master_seed: u64, node_id: u64) -> Self {
+        let seed = derive_seed(master_seed, node_id);
         let radio = SimulatedRadio::new();
         let rng = Xorshift64::new(seed);
         let region = lorawan_device::region::Configuration::new(lorawan_device::Region::EU868);

--- a/examples/lorawan_file_transfer/main.rs
+++ b/examples/lorawan_file_transfer/main.rs
@@ -23,6 +23,13 @@ pub const EU868_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
 pub const INTERFERER_PERIOD_US: u64 = 10_000_000;
 pub const INTERFERER_DURATION_US: u64 = 500_000;
 pub const INTERFERER_SF: u8 = 7;
+
+/// Master PRNG seed for the simulation.
+///
+/// Each node derives its own independent seed from this value combined with
+/// its numeric node ID via [`lorawan_adapter::derive_seed`].  Changing
+/// `SEED` changes every node's sequence simultaneously while keeping all
+/// per-node sequences distinct and reproducible.
 pub const SEED: u64 = 0xDEAD_BEEF_1234_5678;
 
 fn main() {
@@ -31,7 +38,10 @@ fn main() {
 
     let file_data: Vec<u8> = (0..FILE_SIZE).map(|i| (i % 251) as u8).collect();
     let fragmenter = FileFragmenter::new(file_data, CHUNK_SIZE, INTERVAL_US);
-    let device = LoRaWanAdapter::new(NodeId(1), fragmenter, SEED);
+    // Pass the master seed and the node's numeric ID so that LoRaWanAdapter
+    // derives a per-node seed internally, keeping per-node RNG streams
+    // independent even when multiple devices are added to the scheduler.
+    let device = LoRaWanAdapter::new(NodeId(1), fragmenter, SEED, 1);
     let server = NetworkServer::new(NodeId(100));
 
     scheduler.add_node(Box::new(device), Some(0));


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a public `derive_seed(master_seed: u64, node_id: u64) -> u64` function in `lorawan_adapter.rs` that mixes a master seed and a per-node ID using a Knuth/Fibonacci multiplicative hash step (`master_seed ^ node_id.wrapping_mul(0x9e3779b97f4a7c15)`), producing independent, well-distributed seeds for each node.
- Updates `LoRaWanAdapter::new` to accept `(master_seed: u64, node_id: u64)` instead of a raw `seed: u64`; the actual RNG seed is derived internally via `derive_seed`.
- Updates `main.rs` to pass `(SEED, 1)` to `LoRaWanAdapter::new`, and adds a doc-comment explaining that `SEED` is now the master seed from which per-node seeds are derived.

## Motivation

Previously, the same raw constant `SEED` was handed directly to every adapter, giving all nodes identical PRNG streams. The architecture requires per-node seed derivation so that multi-node simulations are both reproducible (same master seed → same results) and independent (different nodes follow different RNG paths).

## Derivation details

```rust
/// per_node_seed = master_seed ^ (node_id.wrapping_mul(0x9e3779b97f4a7c15))
pub fn derive_seed(master_seed: u64, node_id: u64) -> u64 {
    master_seed ^ node_id.wrapping_mul(0x9e3779b97f4a7c15)
}
```

The constant `0x9e3779b97f4a7c15` is the 64-bit fractional part of the golden ratio, a standard choice for Fibonacci hashing. XOR-ing with the master seed ensures that even `node_id = 0` yields a non-trivial seed, and that consecutive node IDs produce seeds that differ across many bits.

## Test plan

- [ ] Verify `cargo build --example lorawan_file_transfer` compiles cleanly on the updated branch.
- [ ] Run `cargo run --example lorawan_file_transfer` and confirm simulation output is identical to the pre-change run (single-node case; `node_id = 1` so `derive_seed(SEED, 1)` replaces the old bare `SEED`).
- [ ] Add a second device with a different `node_id` and confirm that the two nodes emit different TX patterns, demonstrating independent PRNG streams.
- [ ] Confirm re-running with the same `SEED` constant always produces the same output (reproducibility).

https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_