### PR TITLE
refactor(theatron): simplify deliver_completed_to_nodes — remove redundant tx_node_idxs Vec

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -223,23 +223,27 @@ impl Scheduler {
                 if captured {
                     self.metrics.record_capture();
                 }
-                let mut wakes = Vec::new();
-                let mut tx_node_idxs = Vec::new();
+                // First pass: call on_receive on every non-sender node and
+                // collect (index, optional_wake) so we can call self.schedule
+                // and self.handle_poll_transmit in a second pass without
+                // holding a borrow on self.nodes.
+                let mut receiver_results: Vec<(usize, Option<SimTime>)> = Vec::new();
                 for i in 0..self.nodes.len() {
                     if self.nodes[i].node_id() != sender {
                         let node_id = self.nodes[i].node_id();
                         let next = self.nodes[i].on_receive(frame.clone(), time);
                         self.metrics.record_rx(node_id);
-                        if let Some(t) = next {
-                            wakes.push((node_id, t));
-                        }
-                        tx_node_idxs.push(i);
+                        receiver_results.push((i, next));
                     }
                 }
-                for (node_id, t) in wakes {
-                    self.schedule(t, EventKind::Wake { node_id });
-                }
-                for i in tx_node_idxs {
+                // Second pass: schedule any requested wakes and poll for
+                // follow-on transmissions using only indices and wake times
+                // already captured — no second Vec needed.
+                for (i, wake) in receiver_results {
+                    if let Some(t) = wake {
+                        let node_id = self.nodes[i].node_id();
+                        self.schedule(t, EventKind::Wake { node_id });
+                    }
                     self.handle_poll_transmit(i, time);
                 }
             }


### PR DESCRIPTION
## Summary

`deliver_completed_to_nodes` in `src/scheduler.rs` previously used two intermediate `Vec`s to work around the borrow checker:

- `wakes: Vec<(NodeId, SimTime)>` — collected `(NodeId, SimTime)` pairs solely to call `self.schedule` after releasing the borrow on `self.nodes`
- `tx_node_idxs: Vec<usize>` — a redundant copy of the loop indices already iterated, used to call `self.handle_poll_transmit` in a follow-up loop

These two Vecs are mirror images of each other: every index pushed into `tx_node_idxs` corresponds to exactly the same loop iteration that may or may not push into `wakes`. They can be collapsed into a single `Vec<(usize, Option<SimTime>)>`.

### Change

Replace both Vecs with one:

```rust
// before
let mut wakes: Vec<(NodeId, SimTime)> = Vec::new();
let mut tx_node_idxs: Vec<usize> = Vec::new();
for i in 0..self.nodes.len() {
    if self.nodes[i].node_id() != sender {
        let node_id = self.nodes[i].node_id();
        let next = self.nodes[i].on_receive(frame.clone(), time);
        self.metrics.record_rx(node_id);
        if let Some(t) = next {
            wakes.push((node_id, t));
        }
        tx_node_idxs.push(i);
    }
}
for (node_id, t) in wakes {
    self.schedule(t, EventKind::Wake { node_id });
}
for i in tx_node_idxs {
    self.handle_poll_transmit(i, time);
}

// after
let mut receiver_results: Vec<(usize, Option<SimTime>)> = Vec::new();
for i in 0..self.nodes.len() {
    if self.nodes[i].node_id() != sender {
        let node_id = self.nodes[i].node_id();
        let next = self.nodes[i].on_receive(frame.clone(), time);
        self.metrics.record_rx(node_id);
        receiver_results.push((i, next));
    }
}
for (i, wake) in receiver_results {
    if let Some(t) = wake {
        let node_id = self.nodes[i].node_id();
        self.schedule(t, EventKind::Wake { node_id });
    }
    self.handle_poll_transmit(i, time);
}
```

### Effect

- Eliminates one `Vec` allocation per completed (non-colliding) transmission event
- The second pass is now a single loop instead of two, and the `NodeId` for wake scheduling is re-derived from `self.nodes[i]` (already indexed) rather than stored separately
- No behaviour change; all existing tests continue to exercise the same paths

## Test plan

- [ ] `cargo test` passes (all existing unit and property-based tests)
- [ ] `cargo clippy -- -D warnings` passes
- [ ] Verify `receive_triggers_reply_tx`, `rx_returning_wake_schedules_node`, and `broadcast_to_three_receivers` still pass (they exercise both the wake-scheduling and poll-transmit paths touched by this refactor)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_