### PR TITLE
refactor(theatron): consolidate duplicate make_tx test helpers into shared module

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -344,6 +344,10 @@ mod tests {
     use crate::types::{ChannelEvent, Transmission};
     use proptest::prelude::*;
 
+    #[path = "../tests/helpers.rs"]
+    mod helpers;
+    use helpers::make_tx_default as make_tx;
+
     struct SimpleNode {
         id: NodeId,
         pending_tx: Option<Transmission>,
@@ -503,18 +507,6 @@ mod tests {
         }
         fn update(&mut self, _t: SimTime) -> Option<SimTime> {
             None
-        }
-    }
-
-    fn make_tx(sf: u8, frequency: u32, duration_us: u64) -> Transmission {
-        Transmission {
-            payload: vec![0xAB],
-            sf,
-            bandwidth: 125_000,
-            coding_rate: 5,
-            frequency,
-            duration_us,
-            tx_power_dbm: 14,
         }
     }
 

--- a/tests/aloha.rs
+++ b/tests/aloha.rs
@@ -1,3 +1,7 @@
+#[path = "helpers.rs"]
+mod helpers;
+
+use helpers::{make_tx, make_tx_power};
 use theatron::scheduler::{NodeHandle, Scheduler};
 use theatron::time::SimTime;
 use theatron::types::{NodeId, RxMetadata, Transmission};
@@ -7,36 +11,6 @@ use theatron::types::{NodeId, RxMetadata, Transmission};
 // compile only as part of the `aloha` example binary. They validate the
 // scheduler + channel model for ALOHA-like transmission patterns (collision,
 // SF/frequency orthogonality, capture effect) rather than `AlohaNode` itself.
-
-fn make_tx(payload: Vec<u8>, sf: u8, frequency: u32, duration_us: u64) -> Transmission {
-    Transmission {
-        payload,
-        sf,
-        bandwidth: 125_000,
-        coding_rate: 5,
-        frequency,
-        duration_us,
-        tx_power_dbm: 14,
-    }
-}
-
-fn make_tx_power(
-    payload: Vec<u8>,
-    sf: u8,
-    frequency: u32,
-    duration_us: u64,
-    tx_power_dbm: i8,
-) -> Transmission {
-    Transmission {
-        payload,
-        sf,
-        bandwidth: 125_000,
-        coding_rate: 5,
-        frequency,
-        duration_us,
-        tx_power_dbm,
-    }
-}
 
 /// A node that transmits a fixed number of packets at regular intervals.
 struct PeriodicSender {

--- a/tests/core_coverage.rs
+++ b/tests/core_coverage.rs
@@ -4,6 +4,10 @@
 //! gaps identified through coverage analysis: channel edge cases, scheduler
 //! ordering invariants, metrics isolation, and time conversion edge cases.
 
+#[path = "helpers.rs"]
+mod helpers;
+
+use helpers::{tx, tx_with_payload};
 use theatron::channel::Channel;
 use theatron::metrics::MetricsCollector;
 use theatron::scheduler::{NodeHandle, Scheduler};
@@ -16,30 +20,6 @@ use proptest::prelude::*;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn tx(sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
-    Transmission {
-        payload: vec![0xAA],
-        sf,
-        bandwidth: 125_000,
-        coding_rate: 5,
-        frequency: freq,
-        duration_us: dur,
-        tx_power_dbm: power,
-    }
-}
-
-fn tx_with_payload(payload: Vec<u8>, sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
-    Transmission {
-        payload,
-        sf,
-        bandwidth: 125_000,
-        coding_rate: 5,
-        frequency: freq,
-        duration_us: dur,
-        tx_power_dbm: power,
-    }
-}
 
 struct TestNode {
     id: NodeId,

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,0 +1,77 @@
+/// Shared `Transmission` factory helpers used across integration-test files.
+///
+/// All helpers produce a `Transmission` with the standard LoRa defaults:
+///   - bandwidth:    125 000 Hz
+///   - coding_rate:  5
+///
+/// Bring the helpers you need into scope with:
+///
+/// ```rust,ignore
+/// #[path = "helpers.rs"]
+/// mod helpers;
+/// use helpers::{make_tx, make_tx_power};
+/// ```
+use theatron::types::Transmission;
+
+/// Build a `Transmission` with a caller-supplied payload and tx power.
+///
+/// This is the most general factory; all other helpers delegate to it.
+pub fn make_tx_full(
+    payload: Vec<u8>,
+    sf: u8,
+    frequency: u32,
+    duration_us: u64,
+    tx_power_dbm: i8,
+) -> Transmission {
+    Transmission {
+        payload,
+        sf,
+        bandwidth: 125_000,
+        coding_rate: 5,
+        frequency,
+        duration_us,
+        tx_power_dbm,
+    }
+}
+
+/// Build a `Transmission` with a caller-supplied payload and fixed tx power (14 dBm).
+///
+/// Used by `tests/aloha.rs` (was `make_tx`).
+pub fn make_tx(payload: Vec<u8>, sf: u8, frequency: u32, duration_us: u64) -> Transmission {
+    make_tx_full(payload, sf, frequency, duration_us, 14)
+}
+
+/// Build a `Transmission` with a caller-supplied payload and caller-supplied tx power.
+///
+/// Used by `tests/aloha.rs` (was `make_tx_power`).
+pub fn make_tx_power(
+    payload: Vec<u8>,
+    sf: u8,
+    frequency: u32,
+    duration_us: u64,
+    tx_power_dbm: i8,
+) -> Transmission {
+    make_tx_full(payload, sf, frequency, duration_us, tx_power_dbm)
+}
+
+/// Build a `Transmission` with a single-byte payload (`0xAA`) and caller-supplied tx power.
+///
+/// Used by `tests/core_coverage.rs` (was `tx`).
+pub fn tx(sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
+    make_tx_full(vec![0xAA], sf, freq, dur, power)
+}
+
+/// Build a `Transmission` with a caller-supplied payload and caller-supplied tx power.
+///
+/// Alias of [`make_tx_power`]; retained as a distinct name to match the call
+/// sites in `tests/core_coverage.rs` (was `tx_with_payload`).
+pub fn tx_with_payload(payload: Vec<u8>, sf: u8, freq: u32, dur: u64, power: i8) -> Transmission {
+    make_tx_full(payload, sf, freq, dur, power)
+}
+
+/// Build a `Transmission` with a single-byte payload (`0xAB`) and fixed tx power (14 dBm).
+///
+/// Used by `src/scheduler.rs` #[cfg(test)] (was the local `make_tx`).
+pub fn make_tx_default(sf: u8, frequency: u32, duration_us: u64) -> Transmission {
+    make_tx_full(vec![0xAB], sf, frequency, duration_us, 14)
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `tests/aloha.rs`, `tests/core_coverage.rs`, and the `#[cfg(test)]` block in `src/scheduler.rs` each defined their own `make_tx` / `make_tx_power` / `tx` / `tx_with_payload` factory functions that all produced identical `Transmission` structs (bandwidth 125 000, coding_rate 5).
- This PR extracts all variants into a single `tests/helpers.rs` module and replaces each duplicate with a `use` import from that shared module.

## Changes

- **`tests/helpers.rs`** (new): exposes `make_tx_full`, `make_tx`, `make_tx_power`, `tx`, `tx_with_payload`, and `make_tx_default` — one canonical implementation of each factory.
- **`tests/aloha.rs`**: removed local `fn make_tx` and `fn make_tx_power`; added `#[path = "helpers.rs"] mod helpers;` and `use helpers::{make_tx, make_tx_power};`.
- **`tests/core_coverage.rs`**: removed local `fn tx` and `fn tx_with_payload`; added the same path-based module import and `use helpers::{tx, tx_with_payload};`.
- **`src/scheduler.rs`**: removed the local `fn make_tx` from the `#[cfg(test)]` module; added `#[path = "../tests/helpers.rs"] mod helpers;` and aliased `helpers::make_tx_default as make_tx` so all existing call sites remain unchanged.

## Test plan

- [ ] `cargo test` passes with no changes to test logic or assertions
- [ ] No new `allow(dead_code)` suppressions needed — all helper functions are used by at least one call site
- [ ] `cargo clippy` reports no new warnings

https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_