### PR TITLE
feat(theatron): implement RadioMode state machine and two-step TX lifecycle in SimulatedRadio

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -9,7 +9,7 @@ use theatron::types::{NodeId, RxMetadata, Transmission};
 
 use crate::file_fragmenter::FileFragmenter;
 use crate::prng::Xorshift64;
-use crate::simulated_radio::SimulatedRadio;
+use crate::simulated_radio::{SimPhyEvent, SimulatedRadio};
 
 const BUF_SIZE: usize = 255;
 
@@ -18,6 +18,10 @@ pub struct LoRaWanAdapter {
     device: Device<SimulatedRadio, Xorshift64, BUF_SIZE>,
     fragmenter: FileFragmenter,
     pending_timeout_ms: Option<u32>,
+    /// Absolute simulation time (µs) at which the in-flight TX finishes.
+    /// Set when lorawan-device responds with `Response::Txing`; cleared once
+    /// `Phy(TxDone)` has been delivered to the device.
+    tx_end_time: Option<SimTime>,
     tx_start_time: SimTime,
     joined: bool,
 }
@@ -42,6 +46,7 @@ impl LoRaWanAdapter {
             device,
             fragmenter,
             pending_timeout_ms: None,
+            tx_end_time: None,
             tx_start_time: 0,
             joined: true,
         }
@@ -51,6 +56,12 @@ impl LoRaWanAdapter {
         self.tx_start_time + ms as u64 * 1_000
     }
 
+    /// Compute the simulation timestamp (in ms) at which a TX that started at
+    /// `start_us` with duration `duration_us` completes.
+    fn tx_done_timestamp_ms(start_us: SimTime, duration_us: u64) -> u32 {
+        ((start_us + duration_us) / 1_000) as u32
+    }
+
     fn try_send_fragment(&mut self, time: SimTime) -> Option<SimTime> {
         if !self.joined || !self.device.ready_to_send_data() {
             return self.fragmenter.next_available_time(time);
@@ -58,6 +69,28 @@ impl LoRaWanAdapter {
         if let Some(payload) = self.fragmenter.next_payload(time) {
             self.tx_start_time = time;
             match self.device.send(&payload, 1, false) {
+                Ok(Response::Txing) => {
+                    // Step 1 of the two-step TX lifecycle: lorawan-device has
+                    // handed the frame to SimulatedRadio, which has stored it
+                    // in pending_tx.  The scheduler will pick it up via
+                    // poll_transmit and fire a TxComplete event at
+                    // time + duration_us.  We compute that moment now so we
+                    // can schedule a wake-up and deliver TxDone (step 2).
+                    if let Some(tx) = self.device.get_radio().take_pending_tx() {
+                        let end_us = time + tx.duration_us;
+                        self.tx_end_time = Some(end_us);
+                        // Put the transmission back so poll_transmit can
+                        // hand it to the scheduler channel.
+                        // We use a private shim: re-inject it through the
+                        // radio's pending_tx field via the public accessor
+                        // pattern already provided.
+                        self.device.get_radio().set_pending_tx(tx);
+                        Some(end_us)
+                    } else {
+                        None
+                    }
+                }
+                // Defensive: older behaviour or unexpected response.
                 Ok(Response::TimeoutRequest(ms)) => {
                     self.pending_timeout_ms = Some(ms);
                     Some(self.wake_from_timeout(ms))
@@ -84,7 +117,7 @@ impl NodeHandle for LoRaWanAdapter {
         match self
             .device
             .handle_event(lorawan_device::nb_device::Event::RadioEvent(
-                RadioEvent::Phy(()),
+                RadioEvent::Phy(SimPhyEvent::RxDone),
             )) {
             Ok(Response::TimeoutRequest(ms)) => {
                 self.pending_timeout_ms = Some(ms);
@@ -104,6 +137,28 @@ impl NodeHandle for LoRaWanAdapter {
     }
 
     fn update(&mut self, time: SimTime) -> Option<SimTime> {
+        // Step 2 of the two-step TX lifecycle: if we have reached the end of
+        // an in-flight TX, deliver Phy(TxDone) to lorawan-device so it can
+        // open its RX windows.
+        if let Some(end_us) = self.tx_end_time {
+            if time >= end_us {
+                self.tx_end_time = None;
+                let timestamp_ms = (end_us / 1_000) as u32;
+                match self
+                    .device
+                    .handle_event(lorawan_device::nb_device::Event::RadioEvent(
+                        RadioEvent::Phy(SimPhyEvent::TxDone { timestamp_ms }),
+                    )) {
+                    Ok(Response::TimeoutRequest(ms)) => {
+                        self.pending_timeout_ms = Some(ms);
+                        return Some(self.wake_from_timeout(ms));
+                    }
+                    Ok(_) => return None,
+                    Err(_) => return None,
+                }
+            }
+        }
+
         if let Some(_timeout_ms) = self.pending_timeout_ms.take() {
             match self
                 .device

--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -19,8 +19,9 @@ pub struct LoRaWanAdapter {
     fragmenter: FileFragmenter,
     pending_timeout_ms: Option<u32>,
     /// Absolute simulation time (µs) at which the in-flight TX finishes.
-    /// Set when lorawan-device responds with `Response::Txing`; cleared once
-    /// `Phy(TxDone)` has been delivered to the device.
+    /// `Some` after lorawan-device responds with `Response::Txing` (step 1 of
+    /// the two-step TX lifecycle); cleared once `Phy(TxDone)` has been
+    /// delivered back to the device (step 2).
     tx_end_time: Option<SimTime>,
     tx_start_time: SimTime,
     joined: bool,
@@ -56,12 +57,6 @@ impl LoRaWanAdapter {
         self.tx_start_time + ms as u64 * 1_000
     }
 
-    /// Compute the simulation timestamp (in ms) at which a TX that started at
-    /// `start_us` with duration `duration_us` completes.
-    fn tx_done_timestamp_ms(start_us: SimTime, duration_us: u64) -> u32 {
-        ((start_us + duration_us) / 1_000) as u32
-    }
-
     fn try_send_fragment(&mut self, time: SimTime) -> Option<SimTime> {
         if !self.joined || !self.device.ready_to_send_data() {
             return self.fragmenter.next_available_time(time);
@@ -71,26 +66,24 @@ impl LoRaWanAdapter {
             match self.device.send(&payload, 1, false) {
                 Ok(Response::Txing) => {
                     // Step 1 of the two-step TX lifecycle: lorawan-device has
-                    // handed the frame to SimulatedRadio, which has stored it
-                    // in pending_tx.  The scheduler will pick it up via
-                    // poll_transmit and fire a TxComplete event at
-                    // time + duration_us.  We compute that moment now so we
-                    // can schedule a wake-up and deliver TxDone (step 2).
-                    if let Some(tx) = self.device.get_radio().take_pending_tx() {
-                        let end_us = time + tx.duration_us;
+                    // handed the frame to SimulatedRadio which stored it in
+                    // pending_tx.  Read the duration via the non-consuming
+                    // peek accessor so poll_transmit can still hand the frame
+                    // to the scheduler channel.
+                    if let Some(duration_us) =
+                        self.device.get_radio().pending_tx_duration_us()
+                    {
+                        let end_us = time + duration_us;
                         self.tx_end_time = Some(end_us);
-                        // Put the transmission back so poll_transmit can
-                        // hand it to the scheduler channel.
-                        // We use a private shim: re-inject it through the
-                        // radio's pending_tx field via the public accessor
-                        // pattern already provided.
-                        self.device.get_radio().set_pending_tx(tx);
+                        // Return the TX completion time as the next wake-up so
+                        // update() is called at exactly that instant to deliver
+                        // Phy(TxDone) (step 2).
                         Some(end_us)
                     } else {
                         None
                     }
                 }
-                // Defensive: older behaviour or unexpected response.
+                // Defensive: handle any unexpected response gracefully.
                 Ok(Response::TimeoutRequest(ms)) => {
                     self.pending_timeout_ms = Some(ms);
                     Some(self.wake_from_timeout(ms))
@@ -137,9 +130,9 @@ impl NodeHandle for LoRaWanAdapter {
     }
 
     fn update(&mut self, time: SimTime) -> Option<SimTime> {
-        // Step 2 of the two-step TX lifecycle: if we have reached the end of
-        // an in-flight TX, deliver Phy(TxDone) to lorawan-device so it can
-        // open its RX windows.
+        // Step 2 of the two-step TX lifecycle: once the scheduler has advanced
+        // to the TX completion time, deliver Phy(TxDone) to lorawan-device so
+        // it can open its RX1/RX2 windows and return a TimeoutRequest.
         if let Some(end_us) = self.tx_end_time {
             if time >= end_us {
                 self.tx_end_time = None;

--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -7,10 +7,40 @@ use theatron::types::Transmission;
 const RX_WINDOW_DURATION_MS: u32 = 1000;
 const RX_WINDOW_OFFSET_MS: i32 = 0;
 
+/// The current operating mode of the simulated radio.
+///
+/// Mirrors the `RadioMode` sketch in ARCHITECTURE.md so that the TX lifecycle
+/// is a proper two-step sequence:
+///   1. `TxRequest`  → mode transitions to `Txing`, radio returns `Response::Txing`
+///   2. `Phy(SimPhyEvent::TxDone { timestamp_ms })` → mode returns to `Idle`,
+///      radio returns `Response::TxDone(timestamp_ms)`
+#[derive(Debug, Clone)]
+pub enum RadioMode {
+    Idle,
+    Txing { config: TxConfig },
+    Rxing { config: RfConfig },
+}
+
+/// Physical-layer events that the simulation delivers to the radio via
+/// `Event::Phy(SimPhyEvent::...)`.
+///
+/// - `TxDone { timestamp_ms }`: the channel has finished transmitting the
+///   in-flight frame.  The adapter calls this after the scheduler fires a
+///   `TxComplete` event for the node.
+/// - `RxDone`: a downlink has been injected into the receive buffer via
+///   [`SimulatedRadio::inject_downlink`] and the radio should deliver
+///   `Response::RxDone` to the lorawan-device state machine.
+#[derive(Debug, Clone)]
+pub enum SimPhyEvent {
+    TxDone { timestamp_ms: u32 },
+    RxDone,
+}
+
 #[derive(Debug)]
 pub struct SimulatedRadio {
     rx_buf: [u8; 256],
     rx_len: usize,
+    mode: RadioMode,
     pending_tx: Option<Transmission>,
     pending_downlink: Option<Vec<u8>>,
     current_rx_config: Option<RfConfig>,
@@ -21,6 +51,7 @@ impl SimulatedRadio {
         Self {
             rx_buf: [0u8; 256],
             rx_len: 0,
+            mode: RadioMode::Idle,
             pending_tx: None,
             pending_downlink: None,
             current_rx_config: None,
@@ -52,6 +83,12 @@ impl SimulatedRadio {
     pub fn has_pending_downlink(&self) -> bool {
         self.pending_downlink.is_some()
     }
+
+    /// Returns a reference to the current radio mode.
+    #[allow(dead_code)]
+    pub fn mode(&self) -> &RadioMode {
+        &self.mode
+    }
 }
 
 impl Default for SimulatedRadio {
@@ -65,7 +102,7 @@ fn compute_duration_us(bb: &BaseBandModulationParams, payload_len: usize) -> u64
 }
 
 impl PhyRxTx for SimulatedRadio {
-    type PhyEvent = ();
+    type PhyEvent = SimPhyEvent;
     type PhyError = &'static str;
     type PhyResponse = ();
 
@@ -89,7 +126,7 @@ impl PhyRxTx for SimulatedRadio {
                 let TxConfig {
                     pw,
                     rf: RfConfig { frequency, bb, .. },
-                } = tx_config;
+                } = tx_config.clone();
                 let payload = buf.to_vec();
                 let duration_us = compute_duration_us(&bb, payload.len());
                 self.pending_tx = Some(Transmission {
@@ -101,17 +138,34 @@ impl PhyRxTx for SimulatedRadio {
                     duration_us,
                     tx_power_dbm: pw,
                 });
-                Ok(Response::TxDone(0))
+                // Two-step TX lifecycle per ARCHITECTURE.md:
+                // step 1 — transition to Txing and return Response::Txing.
+                // step 2 — caller delivers Phy(SimPhyEvent::TxDone { timestamp_ms })
+                //           once the channel has finished the transmission.
+                self.mode = RadioMode::Txing { config: tx_config };
+                Ok(Response::Txing)
             }
             Event::RxRequest(rf_config) => {
-                self.current_rx_config = Some(rf_config);
+                self.current_rx_config = Some(rf_config.clone());
+                self.mode = RadioMode::Rxing { config: rf_config };
                 Ok(Response::Rxing)
             }
             Event::CancelRx => {
                 self.current_rx_config = None;
+                self.mode = RadioMode::Idle;
                 Ok(Response::Idle)
             }
-            Event::Phy(()) => {
+            Event::Phy(SimPhyEvent::TxDone { timestamp_ms }) => {
+                // Step 2 of the two-step TX lifecycle: the channel has finished
+                // transmitting.  Return to Idle and report the TX timestamp.
+                self.mode = RadioMode::Idle;
+                Ok(Response::TxDone(timestamp_ms))
+            }
+            Event::Phy(SimPhyEvent::RxDone) => {
+                // A downlink was injected via inject_downlink; signal RxDone
+                // so lorawan-device can read get_received_packet().
+                self.mode = RadioMode::Idle;
+                self.current_rx_config = None;
                 if self.pending_downlink.take().is_some() {
                     Ok(Response::RxDone(RxQuality::new(-80, 10)))
                 } else {
@@ -152,6 +206,13 @@ mod tests {
         }
     }
 
+    fn make_tx_config() -> TxConfig {
+        TxConfig {
+            pw: 14,
+            rf: make_rf(),
+        }
+    }
+
     #[test]
     fn new_radio_no_pending_tx() {
         let mut radio = SimulatedRadio::new();
@@ -162,6 +223,12 @@ mod tests {
     fn new_radio_no_pending_downlink() {
         let radio = SimulatedRadio::new();
         assert!(!radio.has_pending_downlink());
+    }
+
+    #[test]
+    fn new_radio_mode_is_idle() {
+        let radio = SimulatedRadio::new();
+        assert!(matches!(radio.mode(), RadioMode::Idle));
     }
 
     #[test]
@@ -180,20 +247,64 @@ mod tests {
         assert_eq!(radio.get_received_packet(), &[0x01, 0x02, 0x03]);
     }
 
+    /// TxRequest must return Txing (step 1 of the two-step TX lifecycle).
     #[test]
-    fn tx_request_populates_pending_tx() {
+    fn tx_request_returns_txing() {
         let mut radio = SimulatedRadio::new();
-        let tx_config = TxConfig {
-            pw: 14,
-            rf: make_rf(),
-        };
         let payload = [0x01, 0x02, 0x03];
-        let result = radio.handle_event(Event::TxRequest(tx_config, &payload));
-        assert!(result.is_ok());
+        let result = radio.handle_event(Event::TxRequest(make_tx_config(), &payload));
+        assert!(
+            matches!(result, Ok(Response::Txing)),
+            "TxRequest must return Response::Txing, got {:?}",
+            result
+        );
+    }
+
+    /// After TxRequest the mode must be Txing and pending_tx must be set.
+    #[test]
+    fn tx_request_sets_txing_mode_and_pending_tx() {
+        let mut radio = SimulatedRadio::new();
+        let payload = [0x01, 0x02, 0x03];
+        let _ = radio.handle_event(Event::TxRequest(make_tx_config(), &payload));
+        assert!(
+            matches!(radio.mode(), RadioMode::Txing { .. }),
+            "mode must be Txing after TxRequest"
+        );
         let tx = radio.take_pending_tx().expect("should have pending tx");
         assert_eq!(tx.sf, TEST_SF);
         assert_eq!(tx.frequency, TEST_FREQ);
         assert_eq!(tx.payload, &[0x01, 0x02, 0x03]);
+    }
+
+    /// Phy(TxDone) must return TxDone(timestamp_ms) and restore Idle mode
+    /// (step 2 of the two-step TX lifecycle).
+    #[test]
+    fn phy_tx_done_returns_tx_done_with_timestamp() {
+        let mut radio = SimulatedRadio::new();
+        let payload = [0xAB];
+        let _ = radio.handle_event(Event::TxRequest(make_tx_config(), &payload));
+        // simulate scheduler delivering TxDone at t=5000 ms
+        let result = radio.handle_event(Event::Phy(SimPhyEvent::TxDone { timestamp_ms: 5000 }));
+        assert!(
+            matches!(result, Ok(Response::TxDone(5000))),
+            "Phy(TxDone) must return Response::TxDone(timestamp_ms), got {:?}",
+            result
+        );
+        assert!(
+            matches!(radio.mode(), RadioMode::Idle),
+            "mode must return to Idle after TxDone"
+        );
+    }
+
+    #[test]
+    fn rx_request_sets_rxing_mode() {
+        let mut radio = SimulatedRadio::new();
+        let result = radio.handle_event(Event::RxRequest(make_rf()));
+        assert!(matches!(result, Ok(Response::Rxing)));
+        assert!(
+            matches!(radio.mode(), RadioMode::Rxing { .. }),
+            "mode must be Rxing after RxRequest"
+        );
     }
 
     #[test]
@@ -203,22 +314,24 @@ mod tests {
         assert!(matches!(result, Ok(Response::Rxing)));
         let result = radio.handle_event(Event::CancelRx);
         assert!(matches!(result, Ok(Response::Idle)));
+        assert!(matches!(radio.mode(), RadioMode::Idle));
     }
 
     #[test]
-    fn phy_with_downlink_returns_rx_done() {
+    fn phy_rx_done_with_downlink_returns_rx_done() {
         let mut radio = SimulatedRadio::new();
         // Enter RX mode and inject downlink
         let _ = radio.handle_event(Event::RxRequest(make_rf()));
         assert!(radio.inject_downlink(vec![0xAB], TEST_SF, TEST_FREQ));
-        let result = radio.handle_event(Event::Phy(()));
+        let result = radio.handle_event(Event::Phy(SimPhyEvent::RxDone));
         assert!(matches!(result, Ok(Response::RxDone(_))));
+        assert!(matches!(radio.mode(), RadioMode::Idle));
     }
 
     #[test]
-    fn phy_without_downlink_returns_idle() {
+    fn phy_rx_done_without_downlink_returns_idle() {
         let mut radio = SimulatedRadio::new();
-        let result = radio.handle_event(Event::Phy(()));
+        let result = radio.handle_event(Event::Phy(SimPhyEvent::RxDone));
         assert!(matches!(result, Ok(Response::Idle)));
     }
 

--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -58,8 +58,21 @@ impl SimulatedRadio {
         }
     }
 
+    /// Consume and return the pending outbound transmission, if any.
+    ///
+    /// Called by `LoRaWanAdapter::poll_transmit` to hand the frame to the
+    /// scheduler channel.
     pub fn take_pending_tx(&mut self) -> Option<Transmission> {
         self.pending_tx.take()
+    }
+
+    /// Return the air-time duration (µs) of the pending outbound transmission
+    /// without consuming it.
+    ///
+    /// Used by the adapter to compute the TxDone wake-up time while leaving
+    /// the `Transmission` available for `poll_transmit`.
+    pub fn pending_tx_duration_us(&self) -> Option<u64> {
+        self.pending_tx.as_ref().map(|t| t.duration_us)
     }
 
     pub fn inject_downlink(&mut self, data: Vec<u8>, sf: u8, frequency: u32) -> bool {
@@ -274,6 +287,19 @@ mod tests {
         assert_eq!(tx.sf, TEST_SF);
         assert_eq!(tx.frequency, TEST_FREQ);
         assert_eq!(tx.payload, &[0x01, 0x02, 0x03]);
+    }
+
+    /// pending_tx_duration_us peeks without consuming.
+    #[test]
+    fn pending_tx_duration_us_peeks_without_consuming() {
+        let mut radio = SimulatedRadio::new();
+        assert_eq!(radio.pending_tx_duration_us(), None);
+        let payload = [0xAB; 10];
+        let _ = radio.handle_event(Event::TxRequest(make_tx_config(), &payload));
+        let dur = radio.pending_tx_duration_us();
+        assert!(dur.is_some(), "should have a duration after TxRequest");
+        // pending_tx must still be intact for poll_transmit
+        assert!(radio.take_pending_tx().is_some(), "take must still work after peek");
     }
 
     /// Phy(TxDone) must return TxDone(timestamp_ms) and restore Idle mode


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `RadioMode { Idle, Txing { config: TxConfig }, Rxing { config: RfConfig } }` enum to `SimulatedRadio`, matching the sketch in ARCHITECTURE.md exactly
- Adds `SimPhyEvent { TxDone { timestamp_ms }, RxDone }` to replace the unit `()` `PhyEvent` type, giving the simulation explicit typed events for both TX completion and RX signalling
- `TxRequest` now transitions the radio to `Txing` mode and returns `Response::Txing` (step 1 of the two-step lifecycle) instead of immediately synthesising `Response::TxDone(0)`
- `Phy(SimPhyEvent::TxDone { timestamp_ms })` transitions back to `Idle` and returns `Response::TxDone(timestamp_ms)` (step 2), carrying the real simulated timestamp
- `Phy(SimPhyEvent::RxDone)` replaces the old `Phy(())` path for RX completion
- Adds `pending_tx_duration_us()` peek accessor on `SimulatedRadio` so the adapter can read the TX duration without consuming the `Transmission` that `poll_transmit` still needs to deliver to the scheduler channel
- Updates `LoRaWanAdapter` to use `SimPhyEvent::RxDone` in `on_receive`, and to drive step 2 from `update()`: after `device.send()` returns `Response::Txing`, the adapter records `tx_end_time` and schedules a wake-up at that moment; `update()` then delivers `Phy(TxDone { timestamp_ms })` so lorawan-device can open its RX1/RX2 windows
- All existing tests updated and new tests added for the `RadioMode` state transitions, the `Txing` → `TxDone(timestamp)` round-trip, and the `pending_tx_duration_us` peek

## Test plan

- [ ] `cargo test -p theatron` — core library tests unchanged
- [ ] `cargo test --example lorawan_file_transfer` — all `simulated_radio` unit tests pass, including new `tx_request_returns_txing`, `tx_request_sets_txing_mode_and_pending_tx`, `phy_tx_done_returns_tx_done_with_timestamp`, `rx_request_sets_rxing_mode`, `pending_tx_duration_us_peeks_without_consuming`
- [ ] `cargo run --example lorawan_file_transfer` — simulation completes without panic; TX/RX counts non-zero

https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_