### PR TITLE
test(scheduler): lock Wake → update + poll_transmit + future-wake invariant

### DIFF
--- a/src/prng.rs
+++ b/src/prng.rs
@@ -119,7 +119,8 @@ mod tests {
         let mut b = Xorshift64::new(9);
         let mut buf_a = [0u8; 16];
         let mut buf_b = [0u8; 16];
-        a.try_fill_bytes(&mut buf_a).expect("try_fill_bytes should never fail");
+        a.try_fill_bytes(&mut buf_a)
+            .expect("try_fill_bytes should never fail");
         b.fill_bytes(&mut buf_b);
         assert_eq!(buf_a, buf_b);
     }

--- a/tests/protocol_timer_contract.rs
+++ b/tests/protocol_timer_contract.rs
@@ -320,3 +320,126 @@ fn same_time_events_fire_in_fifo_order() {
         "updates must fire in registration order when times are equal"
     );
 }
+
+/// On a `Wake` event, the scheduler must (1) call `update`, (2) honor any
+/// `Some(future_t)` it returns by re-scheduling another `Wake` at exactly
+/// `future_t`, AND (3) call `poll_transmit` immediately at the same simulated
+/// time — *all three actions must happen on a single Wake*.
+///
+/// This invariant is what allows protocols to combine "schedule my next timer"
+/// with "send what I have ready right now" without dropping the TX. A
+/// regression that, for example, only invoked `poll_transmit` on Wakes where
+/// `update` returned `None` would silently break every protocol that uses
+/// timer-driven retransmission. See `Scheduler::run`'s `EventKind::Wake` arm
+/// (src/scheduler.rs).
+///
+/// Setup: a single node whose `update` returns `Some(future_t)` AND whose
+/// `poll_transmit` returns `Some(tx)` — both on the very first Wake. We then
+/// assert:
+///   - exactly 1 TX is recorded (the immediate poll fired),
+///   - `update` was called a second time at exactly `future_t` (the rescheduled
+///     Wake fired),
+///   - the recorded `update` call times are `[t0, future_t]` in that order.
+#[test]
+fn wake_invokes_update_then_poll_transmit_and_honors_future_wake() {
+    const FIRST_WAKE: SimTime = 10_000;
+    const FUTURE_WAKE: SimTime = 250_000;
+
+    struct State {
+        update_calls: Vec<SimTime>,
+        poll_calls: Vec<SimTime>,
+        tx_emitted: bool,
+    }
+
+    struct ComboNode {
+        id: NodeId,
+        shared: Rc<RefCell<State>>,
+    }
+
+    impl NodeHandle for ComboNode {
+        fn node_id(&self) -> NodeId {
+            self.id
+        }
+        fn on_receive(&mut self, _: RxMetadata, _: SimTime) -> Option<SimTime> {
+            None
+        }
+        fn poll_transmit(&mut self, time: SimTime) -> Option<Transmission> {
+            let mut s = self.shared.borrow_mut();
+            s.poll_calls.push(time);
+            if s.tx_emitted {
+                return None;
+            }
+            s.tx_emitted = true;
+            Some(Transmission {
+                payload: vec![0xAB],
+                sf: 7,
+                bandwidth: 125_000,
+                coding_rate: 5,
+                frequency: 868_100_000,
+                duration_us: 50_000,
+                tx_power_dbm: 14,
+            })
+        }
+        fn update(&mut self, time: SimTime) -> Option<SimTime> {
+            let mut s = self.shared.borrow_mut();
+            s.update_calls.push(time);
+            // First Wake: schedule a future Wake. Second (future) Wake: stop.
+            if s.update_calls.len() == 1 {
+                Some(FUTURE_WAKE)
+            } else {
+                None
+            }
+        }
+    }
+
+    let shared = Rc::new(RefCell::new(State {
+        update_calls: Vec::new(),
+        poll_calls: Vec::new(),
+        tx_emitted: false,
+    }));
+
+    let mut sched = Scheduler::new(1_000_000);
+    sched.add_node(
+        Box::new(ComboNode {
+            id: NodeId(1),
+            shared: Rc::clone(&shared),
+        }),
+        Some(FIRST_WAKE),
+    );
+    sched.run();
+
+    let s = shared.borrow();
+
+    // Invariant 1: the immediate poll_transmit produced exactly one TX.
+    assert_eq!(
+        sched.metrics.total_tx, 1,
+        "Wake must invoke poll_transmit on the same tick as update; \
+         expected 1 TX from the first Wake, got {}",
+        sched.metrics.total_tx,
+    );
+
+    // Invariant 2: update was called at the initial Wake AND at the future
+    // Wake that update itself requested.
+    assert_eq!(
+        s.update_calls,
+        vec![FIRST_WAKE, FUTURE_WAKE],
+        "update must be called at the initial Wake and again at the wake-time \
+         it returned"
+    );
+
+    // Invariant 3: poll_transmit fires at every Wake, not just when update
+    // returns None. Both calls must happen at the matching Wake times.
+    assert_eq!(
+        s.poll_calls,
+        vec![FIRST_WAKE, FUTURE_WAKE],
+        "poll_transmit must fire on every Wake (after update), independent of \
+         what update returned"
+    );
+
+    // Invariant 4: the rescheduled Wake fired in the future, so current_time
+    // advanced to at least FUTURE_WAKE.
+    assert!(
+        sched.current_time() >= FUTURE_WAKE,
+        "scheduler did not advance to the rescheduled Wake time"
+    );
+}


### PR DESCRIPTION
## Component

`Scheduler::run`'s `EventKind::Wake` arm in `src/scheduler.rs` (≈ lines 279–287), which orchestrates `NodeHandle::update`, future-wake rescheduling, and the immediate `poll_transmit` on a single Wake event.

## Disposition

**Under-tested.** Existing tests verify each action in isolation:
- `scheduler_delivers_wake_at_exact_scheduled_time` (timer-firing time)
- `same_time_events_fire_in_fifo_order` (per-tick ordering across nodes)
- `single_node_tx_is_counted` (poll_transmit fires)

…but none assert the **joint contract** that on a single Wake the scheduler must do *all three* of: (1) call `update`, (2) honor any `Some(future_t)` it returns, **and** (3) call `poll_transmit` *immediately at the same simulated time*. A regression that made (3) conditional on (2) (e.g. only poll if `update` returned `None`) would silently drop transmissions for every timer-driven protocol but pass the existing suite.

## Invariants asserted

1. `Wake` → `poll_transmit` fires on the same tick: exactly 1 TX recorded from a node whose first Wake produces both a future wake-time and a pending TX.
2. `update` is called at both the initial Wake and at the exact `future_t` it returned (`update_calls == [FIRST_WAKE, FUTURE_WAKE]`).
3. `poll_transmit` fires on every Wake (after `update`), independent of what `update` returned (`poll_calls == [FIRST_WAKE, FUTURE_WAKE]`).
4. `Scheduler::current_time()` advances to at least the rescheduled wake.

## Test type

**Integration / contract test** (single new `#[test]` in `tests/protocol_timer_contract.rs`). The right type because the invariant lives at the `NodeHandle` ↔ `Scheduler` boundary and only manifests across a full `Scheduler::run` execution. Not a property test: the contract is deterministic and a single witness case pins all four post-conditions; randomization would obscure intent.

## CI status

Local: `cargo test --test protocol_timer_contract --all-features wake_invokes_update_then_poll_transmit_and_honors_future_wake` → **PASS**.
Pre-commit `cargo test --all-features` hook → **PASS** (full suite green). Will check CI once on first iteration as instructed.

(Includes a one-line `cargo fmt` cleanup in `src/prng.rs` that the local pre-commit hook required to allow any commit; the CI `autoformat` job applies the same.)

https://claude.ai/code/session_01FHpjzuhbpP6qZkEmkmogja

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHpjzuhbpP6qZkEmkmogja)_