### PR TITLE
clarity(tests): use SimTime alias instead of raw u64 in protocol_contract.rs

### DIFF
--- a/src/prng.rs
+++ b/src/prng.rs
@@ -119,7 +119,8 @@ mod tests {
         let mut b = Xorshift64::new(9);
         let mut buf_a = [0u8; 16];
         let mut buf_b = [0u8; 16];
-        a.try_fill_bytes(&mut buf_a).expect("try_fill_bytes should never fail");
+        a.try_fill_bytes(&mut buf_a)
+            .expect("try_fill_bytes should never fail");
         b.fill_bytes(&mut buf_b);
         assert_eq!(buf_a, buf_b);
     }

--- a/tests/protocol_contract.rs
+++ b/tests/protocol_contract.rs
@@ -5,6 +5,7 @@
 //! poll_transmit drains after the first call, and on_receive is safe
 //! to call at any time.
 
+use theatron::time::SimTime;
 use theatron::traits::Protocol;
 use theatron::types::{RxMetadata, Transmission};
 
@@ -22,15 +23,20 @@ impl Protocol for MinimalProtocol {
     type State = MinimalState;
     type Metrics = ();
 
-    fn init(&self, _config: ()) -> (MinimalState, Option<u64>) {
+    fn init(&self, _config: ()) -> (MinimalState, Option<SimTime>) {
         (MinimalState { transmitted: false }, Some(0))
     }
 
-    fn on_receive(&self, _state: &mut MinimalState, _frame: RxMetadata, _time: u64) -> Option<u64> {
+    fn on_receive(
+        &self,
+        _state: &mut MinimalState,
+        _frame: RxMetadata,
+        _time: SimTime,
+    ) -> Option<SimTime> {
         None
     }
 
-    fn poll_transmit(&self, state: &mut MinimalState, _time: u64) -> Option<Transmission> {
+    fn poll_transmit(&self, state: &mut MinimalState, _time: SimTime) -> Option<Transmission> {
         if state.transmitted {
             return None;
         }
@@ -46,7 +52,7 @@ impl Protocol for MinimalProtocol {
         })
     }
 
-    fn update(&self, _state: &mut MinimalState, _time: u64) -> Option<u64> {
+    fn update(&self, _state: &mut MinimalState, _time: SimTime) -> Option<SimTime> {
         None
     }
 


### PR DESCRIPTION
## Concern

`tests/protocol_contract.rs` is the only file in the repo that uses raw `u64` for time-typed `Protocol` trait parameters and returns instead of the `SimTime` type alias. Every other call site — the trait definition in `src/traits.rs`, all other tests (`core_coverage.rs`, `protocol_timer_contract.rs`, `aloha.rs`, `lorawan_*`), every example, and the trait's own doctests (after PR #49) — uses `SimTime`. Mixing raw `u64` with `SimTime` in a contract test that's meant to *exemplify* the trait is exactly the kind of inconsistency that erodes trust in the alias and makes "is this a duration, a time, or a count?" ambiguous at a glance.

## What changed (Edit only — no new docs)

In `tests/protocol_contract.rs`:
- Add `use theatron::time::SimTime;`.
- Replace four signatures' raw `u64` time parameters/returns with `SimTime`:
  - `fn init(...) -> (..., Option<SimTime>)`
  - `fn on_receive(..., _time: SimTime) -> Option<SimTime>`
  - `fn poll_transmit(..., _time: SimTime) -> Option<Transmission>`
  - `fn update(..., _time: SimTime) -> Option<SimTime>`

No behavioural change (`pub type SimTime = u64`). Tests still pass:
`cargo test --test protocol_contract --all-features` → **3 passed**.

Includes a one-line `cargo fmt` cleanup in `src/prng.rs` that the local pre-commit hook required to allow any commit; the CI `autoformat` job applies the same.

Skips: no new docs created, no CHANGELOG/LICENSE touched.

https://claude.ai/code/session_01FHpjzuhbpP6qZkEmkmogja

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHpjzuhbpP6qZkEmkmogja)_