### PR TITLE
refactor(lorawan_adapter): remove dead `joined` field

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -19,7 +19,6 @@ pub struct LoRaWanAdapter {
     fragmenter: FileFragmenter,
     pending_timeout_ms: Option<u32>,
     tx_start_time: SimTime,
-    joined: bool,
     /// Transmission staged during `on_receive` / `update` so that
     /// `poll_transmit` never needs to reach into the radio directly.
     pending_tx: Option<Transmission>,
@@ -46,7 +45,6 @@ impl LoRaWanAdapter {
             fragmenter,
             pending_timeout_ms: None,
             tx_start_time: 0,
-            joined: true,
             pending_tx: None,
         }
     }
@@ -65,7 +63,7 @@ impl LoRaWanAdapter {
     }
 
     fn try_send_fragment(&mut self, time: SimTime) -> Option<SimTime> {
-        if !self.joined || !self.device.ready_to_send_data() {
+        if !self.device.ready_to_send_data() {
             return self.fragmenter.next_available_time(time);
         }
         if let Some(payload) = self.fragmenter.next_payload(time) {


### PR DESCRIPTION
## Summary

`LoRaWanAdapter::joined: bool` is initialised to `true` in `new()` and never mutated again. The only read site is the early-exit guard

```rust
if !self.joined || !self.device.ready_to_send_data() {
    return self.fragmenter.next_available_time(time);
}
```

so `!self.joined` is a permanently-false short-circuit. The field, the initialiser entry, and the dead `||` branch are removed; the rest of `try_send_fragment` is unchanged.

## Why

ARCHITECTURE.md's "Adapter state ownership" section says `Protocol::State` should only carry "bookkeeping theatron needs" — `joined` carries no information at runtime. The change also fits the broader `arch/reduce-redundancy` work stream that targets dead state in the codebase.

## Scope

One file (`examples/lorawan_file_transfer/lorawan_adapter.rs`), one logical change. No behaviour change: `device.ready_to_send_data()` already returns `true` only after the ABP join completes, which is exactly what the dead bool was tracking.

## Test plan
- [x] `cargo check --all-features --all-targets`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --test lorawan_file_transfer` (6/6 passed)
- [x] `cargo test --example lorawan_file_transfer` (18/18 passed)

https://claude.ai/code/session_01C5q6TXtM8gokDqpRTMWRe5

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5q6TXtM8gokDqpRTMWRe5)_