### PR TITLE
docs: trim restate-the-code doctests in metrics and time

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,10 @@
 use crate::types::NodeId;
 use std::collections::HashMap;
 
+/// Counters aggregated over a simulation run.
+///
+/// Behavior of each `record_*` method is exercised by the unit tests in
+/// this module; see those tests for usage examples.
 #[derive(Debug, Default)]
 pub struct MetricsCollector {
     pub total_tx: u64,
@@ -14,123 +18,47 @@ pub struct MetricsCollector {
 
 impl MetricsCollector {
     /// Create a new metrics collector with all counters zeroed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// let m = MetricsCollector::new();
-    /// assert_eq!(m.total_tx, 0);
-    /// assert_eq!(m.total_collisions, 0);
-    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Record a transmission by the given node.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// use theatron::types::NodeId;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_tx(NodeId(1));
-    /// assert_eq!(m.total_tx, 1);
-    /// ```
+    /// Record a transmission by `node`.
     pub fn record_tx(&mut self, node: NodeId) {
         self.total_tx += 1;
         *self.per_node_tx.entry(node).or_insert(0) += 1;
     }
 
-    /// Record a reception by the given node.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// use theatron::types::NodeId;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_rx(NodeId(2));
-    /// assert_eq!(m.total_rx, 1);
-    /// ```
+    /// Record a reception by `node`.
     pub fn record_rx(&mut self, node: NodeId) {
         self.total_rx += 1;
         *self.per_node_rx.entry(node).or_insert(0) += 1;
     }
 
     /// Record a collision event.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_collision();
-    /// assert_eq!(m.total_collisions, 1);
-    /// ```
     pub fn record_collision(&mut self) {
         self.total_collisions += 1;
     }
 
-    /// Record a capture event (a frame successfully decoded despite a simultaneous
-    /// transmission on the same channel, via the radio capture effect).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_capture();
-    /// assert_eq!(m.total_captures, 1);
-    /// ```
+    /// Record a capture event: a frame successfully decoded despite a
+    /// simultaneous transmission on the same channel via the radio capture
+    /// effect.
     pub fn record_capture(&mut self) {
         self.total_captures += 1;
     }
 
-    /// Record airtime used by a transmission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_airtime(1_000_000);
-    /// assert_eq!(m.total_airtime_us, 1_000_000);
-    /// ```
+    /// Record airtime (microseconds) used by a transmission.
     pub fn record_airtime(&mut self, duration_us: u64) {
         self.total_airtime_us += duration_us;
     }
 
-    /// Return the number of transmissions recorded for a node.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// use theatron::types::NodeId;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_tx(NodeId(5));
-    /// m.record_tx(NodeId(5));
-    /// assert_eq!(m.node_tx_count(NodeId(5)), 2);
-    /// assert_eq!(m.node_tx_count(NodeId(99)), 0);
-    /// ```
+    /// Number of transmissions recorded for `node`. Returns 0 if the node
+    /// has not transmitted.
     pub fn node_tx_count(&self, node: NodeId) -> u64 {
         self.per_node_tx.get(&node).copied().unwrap_or(0)
     }
 
-    /// Return the number of receptions recorded for a node.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron::metrics::MetricsCollector;
-    /// use theatron::types::NodeId;
-    /// let mut m = MetricsCollector::new();
-    /// m.record_rx(NodeId(3));
-    /// assert_eq!(m.node_rx_count(NodeId(3)), 1);
-    /// assert_eq!(m.node_rx_count(NodeId(4)), 0);
-    /// ```
+    /// Number of receptions recorded for `node`. Returns 0 if the node has
+    /// not received.
     pub fn node_rx_count(&self, node: NodeId) -> u64 {
         self.per_node_rx.get(&node).copied().unwrap_or(0)
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,34 +1,13 @@
-/// Simulation time in microseconds.
-///
-/// # Examples
-///
-/// ```
-/// use theatron::time::SimTime;
-/// let t: SimTime = 1_000;
-/// assert_eq!(t, 1_000);
-/// ```
+/// Simulation time, expressed as a microsecond-resolution monotonic counter.
 pub type SimTime = u64;
 
-/// Convert simulation time (microseconds) to milliseconds.
-///
-/// # Examples
-///
-/// ```
-/// use theatron::time::sim_time_to_ms;
-/// assert_eq!(sim_time_to_ms(5_000), 5u64);
-/// ```
+/// Convert simulation time (microseconds) to milliseconds, truncating any
+/// sub-millisecond remainder.
 pub fn sim_time_to_ms(t: SimTime) -> u64 {
     t / 1_000
 }
 
 /// Convert milliseconds to simulation time (microseconds).
-///
-/// # Examples
-///
-/// ```
-/// use theatron::time::ms_to_sim_time;
-/// assert_eq!(ms_to_sim_time(5), 5_000);
-/// ```
 pub fn ms_to_sim_time(ms: u32) -> SimTime {
     ms as u64 * 1_000
 }


### PR DESCRIPTION
## Summary

Clears two pockets of low-information `# Examples` boilerplate without losing any documented behavior.

### `src/metrics.rs`
Every public method on `MetricsCollector` carried a ceremonial `# Examples` block whose body was a one-line restate of the method (e.g. `record_collision()` -> `assert_eq!(m.total_collisions, 1)`). The same assertions are already covered by the unit tests in the same module. Removed the seven `# Examples` blocks, kept (and tightened) the one-line doc comments, and added a brief module-level pointer to the unit tests.

### `src/time.rs`
- The `SimTime` type-alias doctest was a tautology (`let t: SimTime = 1_000; assert_eq!(t, 1_000);`) and conveyed nothing. Removed.
- The `sim_time_to_ms` / `ms_to_sim_time` doctests duplicated `one_ms_is_1000_us` in the test module. Removed and clarified the doc summaries (noted truncation behavior of `sim_time_to_ms`).

No public API, behavior, or test coverage changed.

## Test plan
- [ ] `cargo test --all-features` (unit + proptest coverage unchanged)
- [ ] `cargo doc --no-deps` builds without warnings
- [ ] `cargo clippy --all-targets`

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV)_