### PR TITLE
arch: drop always-on prng cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "aloha"
 path = "examples/aloha/main.rs"
 
 [dependencies]
-rand_core = { version = "0.6", default-features = false, optional = true } # optional; see [features] below
+rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
@@ -35,7 +35,3 @@ proptest = "1"
 [profile.release]
 lto = true
 codegen-units = 1
-
-[features]
-default = ["prng"]
-prng = ["rand_core"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod channel;
 pub mod metrics;
-#[cfg(feature = "prng")]
 pub mod prng;
 pub mod scheduler;
 pub mod time;


### PR DESCRIPTION
## Summary

Drops the `prng` Cargo feature and the `optional = true` flag on `rand_core`.

## Why

ARCHITECTURE.md commits theatron to seeded `rand` with explicit RNG threading as a *core* design decision ("Randomness... seeded `rand` with explicit `Rng` threading through all stochastic components. No global RNG."). The `prng` feature was wired so that:

- `default = ["prng"]` enables it unconditionally
- `src/lib.rs` gates `pub mod prng;` behind `#[cfg(feature = "prng")]`
- The lorawan example imports `theatron::prng::Xorshift64` unconditionally, so disabling the feature breaks the only validation target

There is no buildable configuration in which `--no-default-features` succeeds end-to-end. The flag adds a build-matrix dimension with no real coverage and contradicts the architectural decision that randomness threading is *required*, not optional.

## Changes

- `Cargo.toml`: drop `optional = true` on `rand_core`; remove the `[features]` section.
- `src/lib.rs`: remove `#[cfg(feature = "prng")]` gate.

## Precept tied

ARCHITECTURE.md > Key Design Decisions > Randomness: "seeded `rand` with explicit `Rng` threading through all stochastic components." A feature that "removes" the PRNG module contradicts this precept.

## Test plan

- [ ] `cargo check --all-targets`
- [ ] `cargo test`
- [ ] `cargo build --example lorawan_file_transfer`

https://claude.ai/code/session_ecstatic-planck-Ed9Km

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV)_