### PR TITLE
arch: remove dead tx_power_dbm field from PeriodicInterferer

### DIFF
--- a/examples/lorawan_file_transfer/periodic_interferer.rs
+++ b/examples/lorawan_file_transfer/periodic_interferer.rs
@@ -2,12 +2,15 @@ use theatron::time::SimTime;
 use theatron::traits::InterferenceSource;
 use theatron::types::{ChannelEvent, Transmission};
 
+/// EU868 legal TX power for 868.x MHz: 14 dBm. Inlined because every
+/// transmission this interferer injects uses the same value.
+const TX_POWER_DBM: i8 = 14;
+
 pub struct PeriodicInterferer {
     period_us: u64,
     sf: u8,
     frequency: u32,
     duration_us: u64,
-    tx_power_dbm: i8,
 }
 
 impl PeriodicInterferer {
@@ -17,7 +20,6 @@ impl PeriodicInterferer {
             sf,
             frequency,
             duration_us,
-            tx_power_dbm: 14,
         }
     }
 }
@@ -33,7 +35,7 @@ impl InterferenceSource for PeriodicInterferer {
             coding_rate: 5,
             frequency: self.frequency,
             duration_us: self.duration_us,
-            tx_power_dbm: self.tx_power_dbm,
+            tx_power_dbm: TX_POWER_DBM,
         })
     }
 
@@ -60,6 +62,7 @@ mod tests {
         assert_eq!(tx.frequency, 868_100_000);
         assert_eq!(tx.payload, vec![0xFF]);
         assert_eq!(tx.duration_us, 500_000);
+        assert_eq!(tx.tx_power_dbm, TX_POWER_DBM);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`PeriodicInterferer` stores `tx_power_dbm: i8` as a private field, but `new()` is the only constructor and it always assigns `14`. There is no setter and no caller can vary the value. The field is dead state — replace with an inlined constant.

## Why

ARCHITECTURE.md > Core Abstractions > Interference Models defines the interferer surface and frames the validation example as a reference implementation. Carrying a private field that cannot be configured violates the project's stated reduction-of-redundancy posture (`arch/reduce-redundancy` work stream visible in the branch list) and adds bookkeeping that pretends to be configurable while not being so.

## Changes

- Remove `tx_power_dbm` field, constructor initialiser, and reference in `poll_inject`.
- Inline a `TX_POWER_DBM: i8 = 14` module constant with a comment naming EU868 14 dBm legal limit (matches the value used by `AlohaNode::DEFAULT_TX_POWER_DBM`).
- Strengthen `always_injects` test to assert the produced TX power.

## Precept tied

Reduction of complexity / dead state. The field claimed configurability that did not exist.

## Test plan

- [ ] `cargo test --example lorawan_file_transfer`
- [ ] `cargo clippy --all-targets -- -D warnings`

https://claude.ai/code/session_ecstatic-planck-Ed9Km

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV)_