### PR TITLE
arch: replace pending_downlink Vec with bool flag in SimulatedRadio

### DIFF
--- a/examples/lorawan_file_transfer/simulated_radio.rs
+++ b/examples/lorawan_file_transfer/simulated_radio.rs
@@ -12,7 +12,7 @@ pub struct SimulatedRadio {
     rx_buf: [u8; 256],
     rx_len: usize,
     pending_tx: Option<Transmission>,
-    pending_downlink: Option<Vec<u8>>,
+    downlink_ready: bool,
     current_rx_config: Option<RfConfig>,
 }
 
@@ -22,7 +22,7 @@ impl SimulatedRadio {
             rx_buf: [0u8; 256],
             rx_len: 0,
             pending_tx: None,
-            pending_downlink: None,
+            downlink_ready: false,
             current_rx_config: None,
         }
     }
@@ -44,13 +44,8 @@ impl SimulatedRadio {
         let len = data.len().min(256);
         self.rx_buf[..len].copy_from_slice(&data[..len]);
         self.rx_len = len;
-        self.pending_downlink = Some(data);
+        self.downlink_ready = true;
         true
-    }
-
-    #[allow(dead_code)]
-    pub fn has_pending_downlink(&self) -> bool {
-        self.pending_downlink.is_some()
     }
 }
 
@@ -112,7 +107,7 @@ impl PhyRxTx for SimulatedRadio {
                 Ok(Response::Idle)
             }
             Event::Phy(()) => {
-                if self.pending_downlink.take().is_some() {
+                if std::mem::take(&mut self.downlink_ready) {
                     Ok(Response::RxDone(RxQuality::new(-80, 10)))
                 } else {
                     Ok(Response::Idle)
@@ -159,9 +154,9 @@ mod tests {
     }
 
     #[test]
-    fn new_radio_no_pending_downlink() {
+    fn new_radio_no_downlink_ready() {
         let radio = SimulatedRadio::new();
-        assert!(!radio.has_pending_downlink());
+        assert!(!radio.downlink_ready);
     }
 
     #[test]
@@ -218,6 +213,17 @@ mod tests {
     #[test]
     fn phy_without_downlink_returns_idle() {
         let mut radio = SimulatedRadio::new();
+        let result = radio.handle_event(Event::Phy(()));
+        assert!(matches!(result, Ok(Response::Idle)));
+    }
+
+    #[test]
+    fn phy_consumes_downlink_flag() {
+        let mut radio = SimulatedRadio::new();
+        let _ = radio.handle_event(Event::RxRequest(make_rf()));
+        assert!(radio.inject_downlink(vec![0xAB], TEST_SF, TEST_FREQ));
+        let _ = radio.handle_event(Event::Phy(()));
+        // Second Phy event must report Idle: the flag is one-shot.
         let result = radio.handle_event(Event::Phy(()));
         assert!(matches!(result, Ok(Response::Idle)));
     }

--- a/tests/lorawan_frame_correctness.rs
+++ b/tests/lorawan_frame_correctness.rs
@@ -12,7 +12,7 @@ struct MinimalRadio {
     rx_buf: [u8; 256],
     rx_len: usize,
     pending_tx: Option<Transmission>,
-    pending_downlink: Option<Vec<u8>>,
+    downlink_ready: bool,
 }
 
 impl MinimalRadio {
@@ -21,7 +21,7 @@ impl MinimalRadio {
             rx_buf: [0u8; 256],
             rx_len: 0,
             pending_tx: None,
-            pending_downlink: None,
+            downlink_ready: false,
         }
     }
 
@@ -72,7 +72,7 @@ impl PhyRxTx for MinimalRadio {
             Event::RxRequest(_) => Ok(Response::Rxing),
             Event::CancelRx => Ok(Response::Idle),
             Event::Phy(()) => {
-                if self.pending_downlink.take().is_some() {
+                if std::mem::take(&mut self.downlink_ready) {
                     Ok(Response::RxDone(RxQuality::new(-80, 10)))
                 } else {
                     Ok(Response::Idle)


### PR DESCRIPTION
## Summary

`SimulatedRadio` carried `pending_downlink: Option<Vec<u8>>`. The Vec was set in `inject_downlink` to `Some(data)` and consumed only via `pending_downlink.take().is_some()` inside `Event::Phy`. The bytes themselves were never read — payload bytes already live in `rx_buf`, which is what `get_received_packet` returns to the upstream `lorawan-device` state machine. The `Option<Vec<u8>>` was therefore a heap-allocated boolean.

## Changes

- Replace `pending_downlink: Option<Vec<u8>>` with `downlink_ready: bool`.
- `Event::Phy` consumes the flag via `std::mem::take`.
- Drop the dead-coded `has_pending_downlink` helper (annotated `#[allow(dead_code)]`).
- Replace the `new_radio_no_pending_downlink` test (which only exercised the dropped helper) with a test that asserts the flag is consumed one-shot.

## Why

ARCHITECTURE.md > Validation Target > SimulatedRadio sketch describes the radio as maintaining "an internal receive buffer and an RX-mode flag" — the production code carried both that buffer and a redundant Vec carrying the same bytes. This PR brings the implementation back in line with the sketch (a flag plus the buffer) and removes one heap allocation per simulated downlink.

## Precept tied

ARCHITECTURE.md > SimulatedRadio sketch: "an internal receive buffer and an RX-mode flag." The dead Vec contradicted the documented design.

Reduction-of-redundancy: the value carried by `Option<Vec<u8>>` was indistinguishable from `bool`.

## Test plan

- [ ] `cargo test --example lorawan_file_transfer`
- [ ] `cargo test --test lorawan_file_transfer`
- [ ] `cargo clippy --all-targets -- -D warnings`

https://claude.ai/code/session_ecstatic-planck-Ed9Km

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV)_