### PR TITLE
arch: drop dead sender field from EventKind::TxComplete

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -53,7 +53,7 @@ pub trait NodeHandle {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum EventKind {
     Wake { node_id: NodeId },
-    TxComplete { sender: NodeId },
+    TxComplete,
     InterferencePoll { interferer_idx: usize },
 }
 
@@ -210,7 +210,7 @@ impl Scheduler {
             self.metrics.record_tx(sender);
             self.metrics.record_airtime(duration);
             let complete_time = time + duration;
-            self.schedule(complete_time, EventKind::TxComplete { sender });
+            self.schedule(complete_time, EventKind::TxComplete);
         }
     }
 
@@ -289,7 +289,7 @@ impl Scheduler {
                         self.handle_poll_transmit(idx, event.time);
                     }
                 }
-                EventKind::TxComplete { sender: _ } => {
+                EventKind::TxComplete => {
                     let completed_events = self.channel.resolve_at(event.time);
                     for ch_event in &completed_events {
                         for interferer in &mut self.interferers {
@@ -311,12 +311,7 @@ impl Scheduler {
                         }
                         self.metrics.record_airtime(duration);
                         let complete_time = time + duration;
-                        self.schedule(
-                            complete_time,
-                            EventKind::TxComplete {
-                                sender: interferer_node_id,
-                            },
-                        );
+                        self.schedule(complete_time, EventKind::TxComplete);
                     }
                     let next = self.interferers[interferer_idx].next_poll_time(time);
                     if let Some(t) = next {


### PR DESCRIPTION
## Summary

`EventKind::TxComplete { sender: NodeId }` carried a sender id that no consumer ever inspected. The scheduler match arm destructured `sender: _` and the resolution path uses `Channel::resolve_at(time)` to drain whatever transmissions ended at the event's timestamp - the sender is irrelevant at that boundary. Removing the field shrinks the enum and clarifies that `TxComplete` is a pure timestamp tick, not a per-sender notification.

- `EventKind::TxComplete` now a unit variant
- updated the two scheduler call sites that produced `TxComplete { sender }`
- no behaviour change: scheduling and resolution are still timestamp-keyed

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (all suites: unit, integration, doctests)

https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT

---
_Generated by [Claude Code](https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT)_