### PR TITLE
arch: remove dead FileFragmenter::is_done method

### DIFF
--- a/examples/lorawan_file_transfer/file_fragmenter.rs
+++ b/examples/lorawan_file_transfer/file_fragmenter.rs
@@ -20,11 +20,6 @@ impl FileFragmenter {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn is_done(&self) -> bool {
-        self.offset >= self.data.len()
-    }
-
     pub fn next_available_time(&self, current_time: SimTime) -> Option<SimTime> {
         if self.offset >= self.data.len() {
             None


### PR DESCRIPTION
## Summary

`FileFragmenter::is_done()` carried `#[allow(dead_code)]` and is unused anywhere in the workspace - no tests, no example main, no adapter call sites. The two internal locations that need the same boundary check (`next_payload`, `next_available_time`) check `offset >= data.len()` directly. Removing the helper eliminates the dead-code allowance and trims a false API surface from the example.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`

https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT

---
_Generated by [Claude Code](https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT)_