### PR TITLE
cron(test): pin derive_seed reproducibility invariants

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -178,10 +178,15 @@ mod tests {
     /// `(master_seed, node_id)` pair must always produce the same output.
     /// This is the reproducibility guarantee called out in
     /// ARCHITECTURE.md "Randomness".
+    ///
+    /// The concrete expected value pins the formula output:
+    ///   0xDEAD_BEEF ^ (1u64.wrapping_mul(0x9e3779b97f4a7c15))
+    ///   = 0x0000_0000_DEAD_BEEF ^ 0x9e37_79b9_7f4a_7c15
+    ///   = 0x9e37_79b9_a1e7_c2fa
     #[test]
     fn derive_seed_is_deterministic() {
-        assert_eq!(derive_seed(0xDEAD_BEEF, 1), derive_seed(0xDEAD_BEEF, 1));
-        assert_eq!(derive_seed(0, 0), derive_seed(0, 0));
+        assert_eq!(derive_seed(0xDEAD_BEEF, 1), 0x9e3779b9a1e7c2fa_u64);
+        assert_eq!(derive_seed(0, 0), 0);
     }
 
     /// Distinct node ids under the same master seed must produce distinct
@@ -189,12 +194,12 @@ mod tests {
     #[test]
     fn derive_seed_distinguishes_node_ids() {
         let master = 0xDEAD_BEEF_1234_5678u64;
-        let s0 = derive_seed(master, 0);
         let s1 = derive_seed(master, 1);
         let s2 = derive_seed(master, 2);
-        assert_ne!(s0, s1);
+        let s3 = derive_seed(master, 3);
         assert_ne!(s1, s2);
-        assert_ne!(s0, s2);
+        assert_ne!(s2, s3);
+        assert_ne!(s1, s3);
     }
 
     /// Distinct master seeds must produce distinct per-node seeds for the

--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -169,3 +169,50 @@ impl NodeHandle for LoRaWanAdapter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Per-node seed derivation must be deterministic: the same
+    /// `(master_seed, node_id)` pair must always produce the same output.
+    /// This is the reproducibility guarantee called out in
+    /// ARCHITECTURE.md "Randomness".
+    #[test]
+    fn derive_seed_is_deterministic() {
+        assert_eq!(derive_seed(0xDEAD_BEEF, 1), derive_seed(0xDEAD_BEEF, 1));
+        assert_eq!(derive_seed(0, 0), derive_seed(0, 0));
+    }
+
+    /// Distinct node ids under the same master seed must produce distinct
+    /// per-node seeds — otherwise two nodes would share a PRNG stream.
+    #[test]
+    fn derive_seed_distinguishes_node_ids() {
+        let master = 0xDEAD_BEEF_1234_5678u64;
+        let s0 = derive_seed(master, 0);
+        let s1 = derive_seed(master, 1);
+        let s2 = derive_seed(master, 2);
+        assert_ne!(s0, s1);
+        assert_ne!(s1, s2);
+        assert_ne!(s0, s2);
+    }
+
+    /// Distinct master seeds must produce distinct per-node seeds for the
+    /// same node id — otherwise changing the simulation seed would not
+    /// change a given node's stream.
+    #[test]
+    fn derive_seed_distinguishes_master_seeds() {
+        assert_ne!(derive_seed(1, 7), derive_seed(2, 7));
+    }
+
+    /// Pin the boundary: `node_id == 0` makes the multiplicative term zero,
+    /// so `derive_seed` returns the master seed verbatim. This is a known
+    /// property — callers that need node 0 to have a distinct stream must
+    /// offset node ids by 1, as the `lorawan_file_transfer` example does
+    /// (devices use `node_id = 1`, server uses `node_id = 100`).
+    #[test]
+    fn derive_seed_node_zero_returns_master() {
+        assert_eq!(derive_seed(0xABCD, 0), 0xABCD);
+        assert_eq!(derive_seed(0, 0), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- `derive_seed` (in `examples/lorawan_file_transfer/lorawan_adapter.rs`) underpins the per-node PRNG independence and reproducibility guarantee called out in `ARCHITECTURE.md` ("Randomness"), but had zero direct tests. Per-node RNGs sharing a stream — or the seed being silently non-deterministic — would break reproducibility without any test catching it.
- Add four targeted unit tests covering the function's three load-bearing properties plus its `node_id == 0` boundary, with one assertion per property:
  - determinism for the same `(master_seed, node_id)` pair
  - distinct outputs for distinct node ids under one master seed
  - distinct outputs for distinct master seeds at a fixed node id
  - the `node_id == 0` boundary that returns the master seed verbatim — documented inline so future callers know to offset by 1

## Files
- `examples/lorawan_file_transfer/lorawan_adapter.rs` — add a `#[cfg(test)] mod tests` block.

## Test plan
- [x] `cargo test --all-features --example lorawan_file_transfer` — 22 tests pass (was 18; +4)
- [x] `cargo test --all-features` — full suite green


---
_Generated by [Claude Code](https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK)_