### PR TITLE
cron(docs): link ARCHITECTURE and examples from README; fix badge casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
 [![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron/blob/main/LICENSE-MIT)
-[![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
+[![last commit](https://img.shields.io/github/last-commit/DominicBurkart/theatron)](https://github.com/DominicBurkart/theatron)
 
 Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.
+
+- Design and roadmap: [ARCHITECTURE.md](ARCHITECTURE.md)
+- Runnable validation targets: [`examples/aloha`](examples/aloha) (pure ALOHA reference), [`examples/lorawan_file_transfer`](examples/lorawan_file_transfer) (LoRaWAN Class A via `lorawan-device`)


### PR DESCRIPTION
## Summary
- README was a one-liner with no path to either the design doc or the runnable examples. Add two short pointers — `ARCHITECTURE.md` and the `examples/` crates — so new readers can find both the design rationale and a runnable validation target without grepping the tree.
- Normalize the "last commit" badge URL owner from `dominicburkart` to `DominicBurkart` so all four badges agree on canonical casing (the other three already use `DominicBurkart`).

## Files
- `README.md`

## Test plan
- [x] Markdown renders with valid relative links to `ARCHITECTURE.md`, `examples/aloha`, `examples/lorawan_file_transfer`
- [x] Casing of `DominicBurkart` consistent across all badges


---
_Generated by [Claude Code](https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK)_