### PR TITLE
docs: standardize formatting and trim minor redundancy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -236,7 +236,7 @@ LoRaWAN is not peer-to-peer — a server must generate join-accept frames and sc
 - Schedules downlink frames into RX1/RX2 windows
 - Manages frame counters and DevAddr assignment
 
-The server implements `Protocol` and participates in the simulation as a node with network-side visibility. It is part of the lora-rs validation example, not theatron core — consistent with the principle that protocol logic lives outside theatron.
+The server implements `Protocol` and participates in the simulation as a node with network-side visibility. It is part of the lora-rs validation example, not theatron core (see [Protocol logic lives outside theatron](#protocol-logic-lives-outside-theatron)).
 
 ### Channel / Medium
 
@@ -263,11 +263,11 @@ Planned interference models:
 - **Selective jamming**: targeted interference against specific SFs or node addresses
 - **Passive eavesdropper**: traffic analysis without injection
 
-### Metrics collection
+### Metrics Collection
 
 A passive observer attached to the simulation that records per-protocol, per-run statistics: throughput (frames/s per SF), PDR, latency distribution, time-on-air, retransmission count, protocol-specific session establishment metrics (e.g. join success rate in LoRaWAN), and protocol-specific counters. Output in a structured format suitable for statistical comparison across runs.
 
-### Hardware measurement tooling (potential expansion)
+### Hardware Measurement Tooling (potential expansion)
 
 To ground simulations in real-world conditions, theatron may include tooling for capturing LoRa hardware connection characteristics — RSSI profiles, SNR distributions, interference patterns, and timing measurements from physical deployments. These measurements would be uploaded as empirical channel model inputs, allowing simulations to reflect actual deployment conditions.
 
@@ -322,7 +322,7 @@ To ground simulations in real-world conditions, theatron may include tooling for
 
 ### SimTime resolution
 
-**`SimTime` is a microsecond-resolution monotonic `u64` counter.** Microseconds are required for `lora-modulation`'s time-on-air calculations (which return `u64` microseconds) and for precise collision detection at high SFs. `lorawan-device`'s `TimestampMs` (`u32` milliseconds) is a subset; conversion is `timestamp_ms = (sim_time / 1_000) as u32`. Symbol times at SF7/125kHz are ~1ms; time-on-air at SF12/125kHz is ~2.5s — both fit comfortably in microsecond `u64`.
+**`SimTime` is a microsecond-resolution monotonic `u64` counter.** Microseconds are required for `lora-modulation`'s time-on-air calculations (which return `u64` microseconds) and for precise collision detection at high SFs. `lorawan-device`'s `TimestampMs` (`u32` milliseconds) is a subset; conversion is `timestamp_ms = (sim_time / 1_000) as u32`. Symbol times at SF7/125 kHz are ~1ms; time-on-air at SF12/125 kHz is ~2.5s — both fit comfortably in microsecond `u64`.
 
 ### Frame representation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
-[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron/blob/main/LICENSE-MIT)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE-MIT)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
 
 Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.


### PR DESCRIPTION
Conservative documentation cleanup focused on consistency. No substantive content changed.

## Changes

- **`README.md`**: Convert the `LICENSE-MIT` badge link from an absolute `https://github.com/.../blob/main/LICENSE-MIT` URL to a relative `LICENSE-MIT` link. Rationale: relative links work when the README is rendered in forks, branches, and offline tools; aligns with the standard set in the task brief.
- **`ARCHITECTURE.md`**: Standardize `125kHz` -> `125 kHz` (two occurrences in the SimTime resolution section). Rationale: SI-style spacing matches the existing convention in `src/channel.rs:9` (`SF7/125 kHz`).
- **`ARCHITECTURE.md`**: Title-case two outlier H3 headings under "Core Abstractions" (`Metrics collection` -> `Metrics Collection`, `Hardware measurement tooling` -> `Hardware Measurement Tooling`). Rationale: sibling H3 headings in the same section (`Validation Target`, `Channel / Medium`, `Interference Models`) are Title Case; this removes the inconsistency.
- **`ARCHITECTURE.md`**: Replace the dangling restatement "consistent with the principle that protocol logic lives outside theatron" at the end of the "Simulated network server" subsection with a relative anchor link to the dedicated design-decision section. Rationale: avoids restating the same principle twice in the same document; the design-decision section remains the single source of truth.

## Findings

Docs are otherwise tight. No outdated references, no date strings, no broken cross-references. Module-level rustdoc and doctests are concise. No code-pointer style inconsistencies in docs (none use file:line pointers). Em-dash and code-fence usage are uniform throughout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_