### PR TITLE
arch(channel): demote LoRa default constants to private

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -4,13 +4,13 @@ use crate::types::{ChannelEvent, NodeId, RxMetadata, Transmission};
 pub type CompletedTx = (NodeId, bool, bool, RxMetadata);
 
 /// Default LoRa path loss in dB (free-space + typical indoor attenuation baseline).
-pub const LORA_PATH_LOSS_DB: f32 = 100.0;
+const LORA_PATH_LOSS_DB: f32 = 100.0;
 
 /// Default LoRa noise floor in dBm (LoRa sensitivity at SF7/125 kHz).
-pub const LORA_NOISE_FLOOR_DBM: f32 = -117.0;
+const LORA_NOISE_FLOOR_DBM: f32 = -117.0;
 
 /// Default co-channel rejection threshold in dB (LoRa capture effect threshold).
-pub const LORA_CO_CHANNEL_REJECTION_DB: f32 = 6.0;
+const LORA_CO_CHANNEL_REJECTION_DB: f32 = 6.0;
 
 /// Configuration for physical-layer channel parameters.
 ///


### PR DESCRIPTION
## Summary

`LORA_PATH_LOSS_DB`, `LORA_NOISE_FLOOR_DBM`, and `LORA_CO_CHANNEL_REJECTION_DB` in `src/channel.rs` are exposed as `pub const` but only consumed inside the same module (by `ChannelConfig::lora_defaults` and a single in-module test). No code in `tests/`, `examples/`, or other library modules references them.

ARCHITECTURE.md states the principle that protocol-specific tuning lives outside theatron and that `ChannelConfig::lora_defaults()` is the canonical entry point for LoRa parameters. Exporting these raw constants alongside the structured config method:
- expands the public API for no observed external use,
- gives consumers two ways to obtain the same values (drift risk),
- adds noise to rustdoc.

This PR removes the `pub` modifier so the constants remain module-local. `ChannelConfig::lora_defaults()` continues to be the public entry point and its return value is unchanged.

## Test plan
- [ ] `cargo test --lib channel` passes (verified locally)
- [ ] `cargo test --all-targets` still passes
- [ ] No external consumer broken (none exists in this repo)

https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_