### PR TITLE
arch(example): drop dead per-fragment bookkeeping in NetworkServer

### DIFF
--- a/examples/lorawan_file_transfer/network_server.rs
+++ b/examples/lorawan_file_transfer/network_server.rs
@@ -2,29 +2,21 @@ use theatron::scheduler::NodeHandle;
 use theatron::time::SimTime;
 use theatron::types::{NodeId, RxMetadata, Transmission};
 
+/// Stub LoRaWAN network server used by the file-transfer example.
+///
+/// The architecture treats the network server as an external simulation
+/// participant; for this example we only need a node that consumes uplinks
+/// so the scheduler-level RX metrics (`MetricsCollector::node_rx_count`)
+/// reflect end-to-end delivery. Per-fragment payload accumulation was
+/// previously stored on this struct but never read, so the receive path is
+/// now a no-op and the bookkeeping fields are gone.
 pub struct NetworkServer {
     id: NodeId,
-    received_fragments: Vec<Vec<u8>>,
-    total_bytes_received: usize,
 }
 
 impl NetworkServer {
     pub fn new(id: NodeId) -> Self {
-        Self {
-            id,
-            received_fragments: Vec::new(),
-            total_bytes_received: 0,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn received_fragments(&self) -> &[Vec<u8>] {
-        &self.received_fragments
-    }
-
-    #[allow(dead_code)]
-    pub fn total_bytes_received(&self) -> usize {
-        self.total_bytes_received
+        Self { id }
     }
 }
 
@@ -33,9 +25,7 @@ impl NodeHandle for NetworkServer {
         self.id
     }
 
-    fn on_receive(&mut self, frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
-        self.total_bytes_received += frame.payload.len();
-        self.received_fragments.push(frame.payload);
+    fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
         None
     }
 
@@ -64,19 +54,14 @@ mod tests {
     }
 
     #[test]
-    fn new_server_empty() {
-        let server = NetworkServer::new(NodeId(100));
-        assert_eq!(server.received_fragments().len(), 0);
-        assert_eq!(server.total_bytes_received(), 0);
-    }
-
-    #[test]
-    fn on_receive_accumulates() {
+    fn on_receive_returns_none() {
         let mut server = NetworkServer::new(NodeId(100));
-        server.on_receive(make_frame(vec![0x01, 0x02]), 0);
-        server.on_receive(make_frame(vec![0x03]), 1000);
-        assert_eq!(server.received_fragments().len(), 2);
-        assert_eq!(server.total_bytes_received(), 3);
+        assert!(
+            server
+                .on_receive(make_frame(vec![0x01, 0x02]), 0)
+                .is_none()
+        );
+        assert!(server.on_receive(make_frame(vec![0x03]), 1000).is_none());
     }
 
     #[test]
@@ -91,5 +76,11 @@ mod tests {
         let mut server = NetworkServer::new(NodeId(100));
         assert!(server.update(0).is_none());
         assert!(server.update(1_000_000).is_none());
+    }
+
+    #[test]
+    fn node_id_returned_unchanged() {
+        let server = NetworkServer::new(NodeId(100));
+        assert_eq!(server.node_id(), NodeId(100));
     }
 }


### PR DESCRIPTION
## Summary

`NetworkServer` in the LoRaWAN file-transfer example accumulates `received_fragments: Vec<Vec<u8>>` and a running byte counter on every uplink, but neither value is ever read outside the unit test that exercises the accessor itself. Both accessors are gated with `#[allow(dead_code)]`. End-to-end delivery is already observable via `Scheduler::metrics.node_rx_count(NodeId(100))` in `main.rs`.

This PR removes the dead fields, accessors, and the corresponding mutation in `on_receive`. Net effect:
- one fewer heap allocation per uplink in the example,
- the struct no longer misrepresents itself as carrying server-side state (ARCHITECTURE.md describes a real network server as deriving keys, generating join-accept frames, and scheduling downlinks - none of which this stub does),
- tests are simplified to assert the no-op contract.

## Test plan
- [ ] `cargo test --test lorawan_file_transfer` passes (verified locally: 6/6)
- [ ] `cargo test --example lorawan_file_transfer` passes (verified locally: 18/18)
- [ ] `cargo build --tests --examples` clean

https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_