### PR TITLE
docs: tighten architecture references and remove redundant comments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,8 +79,6 @@ Invalid transitions become compile errors. For adapter integrations, correctness
 
 #### LoRaWAN Class A state flow (validation target reference)
 
-The following illustrates the validation target's state machine for reference:
-
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
@@ -240,7 +238,7 @@ The server implements `Protocol` and participates in the simulation as a node wi
 
 ### Channel / Medium
 
-A shared simulation object that models the physical wireless channel: propagation delay, collision detection, RSSI and SNR derivation, SF orthogonality approximation, and time-on-air gating. The channel model is parameterized; in the validation case it is configured for LoRa using `lora-modulation`. The channel carries `Vec<u8>` payloads alongside `TxMetadata` (SF, bandwidth, frequency, TX power). Protocol adapters parse the raw bytes via their respective crates; the channel remains format-agnostic.
+A shared simulation object that models the physical wireless channel: propagation delay, collision detection, RSSI and SNR derivation, SF orthogonality approximation, and time-on-air gating. The channel model is parameterized; in the validation case it is configured for LoRa using `lora-modulation`. The channel carries `Vec<u8>` payloads alongside `Transmission` metadata (SF, bandwidth, frequency, TX power). Protocol adapters parse the raw bytes via their respective crates; the channel remains format-agnostic.
 
 All communication flows through the channel — protocols and interference sources do not interact directly.
 
@@ -326,7 +324,7 @@ To ground simulations in real-world conditions, theatron may include tooling for
 
 ### Frame representation
 
-**Concrete: the channel carries `Vec<u8>` + `TxMetadata`.** Protocol adapters use their respective crates (e.g. `lorawan` for LoRaWAN) to parse and construct frames. The channel stays format-agnostic; type safety lives at the protocol layer, not the channel layer.
+**Concrete: the channel carries `Vec<u8>` + `Transmission` metadata.** Protocol adapters use their respective crates (e.g. `lorawan` for LoRaWAN) to parse and construct frames. The channel stays format-agnostic; type safety lives at the protocol layer, not the channel layer.
 
 ### Interference source visibility
 

--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -126,8 +126,6 @@ impl NodeHandle for LoRaWanAdapter {
             .handle_event(lorawan_device::nb_device::Event::RadioEvent(
                 RadioEvent::Phy(()),
             ));
-        // Stage any transmission the device queued onto the radio before
-        // returning, so poll_transmit only needs to drain the adapter field.
         self.stage_pending_tx();
         match result {
             Ok(Response::TimeoutRequest(ms)) => {
@@ -152,8 +150,6 @@ impl NodeHandle for LoRaWanAdapter {
             let result = self
                 .device
                 .handle_event(lorawan_device::nb_device::Event::TimeoutFired);
-            // Stage any transmission produced by the timeout event before
-            // inspecting the response variant.
             self.stage_pending_tx();
             match result {
                 Ok(Response::TimeoutRequest(ms)) => {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -223,10 +223,8 @@ impl Scheduler {
                 if captured {
                     self.metrics.record_capture();
                 }
-                // First pass: call on_receive on every non-sender node and
-                // collect (index, optional_wake) so we can call self.schedule
-                // and self.handle_poll_transmit in a second pass without
-                // holding a borrow on self.nodes.
+                // Two-pass to avoid holding a borrow on self.nodes while
+                // calling self.schedule / self.handle_poll_transmit.
                 let mut receiver_results: Vec<(usize, Option<SimTime>)> = Vec::new();
                 for i in 0..self.nodes.len() {
                     if self.nodes[i].node_id() != sender {
@@ -236,9 +234,6 @@ impl Scheduler {
                         receiver_results.push((i, next));
                     }
                 }
-                // Second pass: schedule any requested wakes and poll for
-                // follow-on transmissions using only indices and wake times
-                // already captured — no second Vec needed.
                 for (i, wake) in receiver_results {
                     if let Some(t) = wake {
                         let node_id = self.nodes[i].node_id();


### PR DESCRIPTION
## Summary

Conservative clarity pass: condense and standardize without rewriting.

- [`ARCHITECTURE.md`](ARCHITECTURE.md#L241): replace stale `TxMetadata` with `Transmission` (the actual type defined in [`src/types.rs`](src/types.rs#L62)). Same correction applied at [ARCHITECTURE.md#L327](ARCHITECTURE.md#L327).
- [`ARCHITECTURE.md`](ARCHITECTURE.md#L80): drop the lead-in line under the "LoRaWAN Class A state flow (validation target reference)" heading; the heading already says it.
- [`src/scheduler.rs`](src/scheduler.rs#L226): collapse the verbose two-pass narration in `deliver_completed_to_nodes` to a single line that names the borrow constraint motivating the pattern.
- [`examples/lorawan_file_transfer/lorawan_adapter.rs`](examples/lorawan_file_transfer/lorawan_adapter.rs#L129): drop two inline comments that paraphrased `stage_pending_tx`'s docstring.

Net: 4 insertions, 15 deletions across 3 files. No code or behavior changes.

## Test plan

- [x] `cargo check` passes locally
- [ ] CI green

## Notes

Designated branch `claude/ecstatic-planck-dwPpr` did not exist on origin; sub-branch was created from `origin/main` per the cron-workflow fallback.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_