### PR TITLE
arch(scheduler): extract synthetic_interferer_id helper

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -76,6 +76,15 @@ impl PartialOrd for ScheduledEvent {
     }
 }
 
+/// Synthesise a `NodeId` for the interferer at index `idx`.
+///
+/// Interferers occupy the high end of the `NodeId` space (`u32::MAX`
+/// counting down) so that `add_node` can `debug_assert!` against
+/// collisions without needing to consult a separate registry.
+fn synthetic_interferer_id(idx: usize) -> NodeId {
+    NodeId(u32::MAX - idx as u32)
+}
+
 /// The simulation scheduler, which drives all nodes and interferers.
 pub struct Scheduler {
     events: BinaryHeap<ScheduledEvent>,
@@ -162,7 +171,7 @@ impl Scheduler {
     /// ```
     pub fn add_node(&mut self, node: Box<dyn NodeHandle>, initial_wake: Option<SimTime>) {
         debug_assert!(
-            (0..self.interferers.len()).all(|i| node.node_id().0 != u32::MAX - i as u32),
+            (0..self.interferers.len()).all(|i| node.node_id() != synthetic_interferer_id(i)),
             "NodeId({}) collides with interferer ID space",
             node.node_id().0
         );
@@ -175,10 +184,10 @@ impl Scheduler {
 
     pub fn add_interferer(&mut self, interferer: Box<dyn InterferenceSource>, first_poll: SimTime) {
         let idx = self.interferers.len();
-        let synthetic_id = u32::MAX - idx as u32;
+        let synthetic_id = synthetic_interferer_id(idx);
         debug_assert!(
-            self.nodes.iter().all(|n| n.node_id().0 != synthetic_id),
-            "interferer synthetic NodeId({synthetic_id}) collides with a registered node"
+            self.nodes.iter().all(|n| n.node_id() != synthetic_id),
+            "interferer synthetic {synthetic_id:?} collides with a registered node"
         );
         self.interferers.push(interferer);
         self.schedule(
@@ -302,7 +311,7 @@ impl Scheduler {
                     let time = event.time;
                     if let Some(tx) = self.interferers[interferer_idx].poll_inject(time) {
                         let duration = tx.duration_us;
-                        let interferer_node_id = NodeId(u32::MAX - interferer_idx as u32);
+                        let interferer_node_id = synthetic_interferer_id(interferer_idx);
                         let ch_event =
                             self.channel
                                 .begin_transmission(interferer_node_id, &tx, time);


### PR DESCRIPTION
## Rule cited

ARCHITECTURE.md, "Interference Models":

> Interference sources are first-class simulation participants. They observe the channel subject to the same physical constraints as legitimate nodes and may inject frames or noise.

The implementation contract that lets interferers and nodes share a single `NodeId` space (without a separate registry) is the formula `interferer_idx -> NodeId(u32::MAX - idx as u32)`. Today that formula is open-coded in three places — `add_node`'s `debug_assert!`, `add_interferer`'s synthetic-id allocation, and the `EventKind::InterferencePoll` branch in `Scheduler::run`. Triplicating a load-bearing convention violates basic DRY and means a future change has to touch all three sites in lock-step.

## What this PR does

Introduces a private file-level helper:

```rust
fn synthetic_interferer_id(idx: usize) -> NodeId {
    NodeId(u32::MAX - idx as u32)
}
```

…and routes the three call sites through it. Side benefit: `add_node` and `add_interferer` can now compare `NodeId == NodeId` (via the existing `PartialEq` derive on `NodeId`) instead of unwrapping to `.0` and comparing raw `u32`s, so the assertion reads as "a node and an interferer cannot share an ID" rather than as bit-arithmetic.

The `add_interferer` panic message now formats the full `NodeId(...)` via `{:?}` so the code no longer hand-writes the `"synthetic NodeId({})"` template alongside the value — one less place to drift if the `NodeId` debug format ever changes.

No public API change, no behaviour change.

## Test plan

- [x] `cargo build`
- [x] `cargo test --lib` — 64/64 pass (including `add_node_after_interferer_validates_id_space` which exercises the `debug_assert!`)
- [x] `cargo test --tests` — all integration tests pass
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`

https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_