### PR TITLE
docs: trim duplication and standardize references for clarity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ The scheduler calls `poll_transmit` on the protocol; the protocol (or its adapte
 
 ### Validation Target: LoRaWAN via lora-rs
 
-LoRaWAN via lora-rs is the first real-world protocol used to prove the simulation engine works with a real stack. The validation example is external to theatron core and comprises three components:
+LoRaWAN via lora-rs is the first real-world protocol used to prove the simulation engine works with a real stack. The validation example lives outside theatron core and comprises three components:
 
 - **LoRaWAN device adapter**: wraps `lorawan-device::nb_device` to implement the `Protocol` trait
 - **Simulated network server**: responds to joins and schedules downlinks (see below)
@@ -237,7 +237,7 @@ LoRaWAN is not peer-to-peer — a server must generate join-accept frames and sc
 - Schedules downlink frames into RX1/RX2 windows
 - Manages frame counters and DevAddr assignment
 
-The server implements `Protocol` and participates in the simulation as a node with network-side visibility. It is part of the lora-rs validation example, not theatron core — consistent with the principle that protocol logic lives outside theatron.
+The server implements `Protocol` and participates in the simulation as a node with network-side visibility. It ships with the validation example, not theatron core — see [Protocol logic lives outside theatron](#protocol-logic-lives-outside-theatron).
 
 ### Channel / Medium
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/theatron.svg)](https://crates.io/crates/theatron)
 [![docs.rs](https://img.shields.io/docsrs/theatron.svg)](https://docs.rs/theatron)
-[![CI](https://github.com/DominicBurkart/theatron/workflows/CI/badge.svg)](https://github.com/DominicBurkart/theatron/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/DominicBurkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/theatron)
-[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/theatron)
-[![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/DominicBurkart/theatron)
+[![CI](https://github.com/dominicburkart/theatron/workflows/CI/badge.svg)](https://github.com/dominicburkart/theatron/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/dominicburkart/theatron/branch/main/graph/badge.svg)](https://codecov.io/gh/dominicburkart/theatron)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/dominicburkart/theatron/blob/main/LICENSE-MIT)
+[![last commit](https://img.shields.io/github/last-commit/dominicburkart/theatron)](https://github.com/dominicburkart/theatron)
 
 Simulation framework for evaluating and comparing wireless protocol implementations under network-level effects.
 

--- a/examples/aloha/aloha_node.rs
+++ b/examples/aloha/aloha_node.rs
@@ -71,18 +71,14 @@ impl AlohaNode {
             });
             Some(time)
         } else {
-            // Check whether traffic can ever produce another payload. If the
-            // model has a fixed count and it is exhausted, stop scheduling.
-            // We probe one interval ahead; if still None at a future time, we
-            // assume exhaustion — TrafficModel::next_payload is idempotent for
-            // a depleted PeriodicTraffic (remaining == 0 always returns None).
+            // Probe one poll interval ahead: if the traffic model still has
+            // nothing then, treat it as permanently exhausted and stop
+            // rescheduling. PeriodicTraffic's `next_payload` is safe to call
+            // early; it gates on `time >= next_time` rather than consuming.
             let future = time + self.poll_interval_us;
             if self.traffic.next_payload(future).is_none() {
-                None // traffic permanently exhausted — do not reschedule
+                None
             } else {
-                // Payload will be ready in the future; wake up and check again.
-                // (next_payload consumed the future slot, but PeriodicTraffic
-                //  re-checks time >= next_time, so calling it early is safe.)
                 Some(future)
             }
         }
@@ -95,8 +91,7 @@ impl NodeHandle for AlohaNode {
     }
 
     /// Pure ALOHA is "transmit and forget": no ACK or retransmission, so the
-    /// sender ignores incoming frames. ACK-based retransmission would use this
-    /// hook plus a new `on_tx_complete` scheduler callback for collision backoff.
+    /// sender ignores incoming frames.
     fn on_receive(&mut self, _frame: RxMetadata, _time: SimTime) -> Option<SimTime> {
         None
     }

--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -176,13 +176,9 @@ mod tests {
 
     /// Per-node seed derivation must be deterministic: the same
     /// `(master_seed, node_id)` pair must always produce the same output.
-    /// This is the reproducibility guarantee called out in
-    /// ARCHITECTURE.md "Randomness".
-    ///
-    /// The concrete expected value pins the formula output:
-    ///   0xDEAD_BEEF ^ (1u64.wrapping_mul(0x9e3779b97f4a7c15))
-    ///   = 0x0000_0000_DEAD_BEEF ^ 0x9e37_79b9_7f4a_7c15
-    ///   = 0x9e37_79b9_a1e7_c2fa
+    /// This is the reproducibility guarantee from `ARCHITECTURE.md` §
+    /// "Randomness". The pinned value below is `0xDEAD_BEEF XOR
+    /// (1 * 0x9e3779b97f4a7c15) = 0x9e3779b9a1e7c2fa`.
     #[test]
     fn derive_seed_is_deterministic() {
         assert_eq!(derive_seed(0xDEAD_BEEF, 1), 0x9e3779b9a1e7c2fa_u64);


### PR DESCRIPTION
## Summary

Focused docs/comment clarity pass. No behaviour or API changes; `cargo check --all-targets`, `cargo test --doc`, and `cargo test --lib` all pass.

- **README**: normalize repo-owner casing across badge URLs (`DominicBurkart` -> `dominicburkart` so every GitHub link uses the same canonical case); point the license badge at `LICENSE-MIT` instead of the repo root so the link target matches what the badge advertises.
- **ARCHITECTURE.md**: collapse a duplicated explanation of where the lora-rs validation example lives into a single intra-doc link to the existing "Protocol logic lives outside theatron" section, and tweak one redundant phrasing ("external to theatron core" -> "lives outside theatron core") to match the wording used elsewhere.
- **examples/aloha/aloha_node.rs**: drop a stale doc comment that referenced a hypothetical `on_tx_complete` scheduler callback which does not exist on the current `NodeHandle` API; tighten the verbose "probe one interval ahead" comment in `try_generate_tx` so it states the invariant directly without the digression about idempotence.
- **examples/lorawan_file_transfer/lorawan_adapter.rs**: condense the `derive_seed_is_deterministic` test commentary. The four-line pinned-value walkthrough becomes a single sentence that still names the formula and the expected result; the cross-reference to `ARCHITECTURE.md` § "Randomness" is preserved.

## Test plan

- [x] `cargo check --all-targets` (clean)
- [x] `cargo test --doc` (34 passed)
- [x] `cargo test --lib` (64 passed)
- [ ] CI green on the pushed branch

https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb)_