### PR TITLE
arch(example): drop redundant prng module shim in lorawan_file_transfer

### DIFF
--- a/examples/lorawan_file_transfer/lorawan_adapter.rs
+++ b/examples/lorawan_file_transfer/lorawan_adapter.rs
@@ -2,13 +2,13 @@ use lorawan_device::nb_device::radio::Event as RadioEvent;
 use lorawan_device::nb_device::{Device, Response};
 use lorawan_device::{AppSKey, DevAddr, JoinMode, NewSKey};
 
+use theatron::prng::Xorshift64;
 use theatron::scheduler::NodeHandle;
 use theatron::time::SimTime;
 use theatron::traits::TrafficModel;
 use theatron::types::{NodeId, RxMetadata, Transmission};
 
 use crate::file_fragmenter::FileFragmenter;
-use crate::prng::Xorshift64;
 use crate::simulated_radio::SimulatedRadio;
 
 const BUF_SIZE: usize = 255;

--- a/examples/lorawan_file_transfer/main.rs
+++ b/examples/lorawan_file_transfer/main.rs
@@ -2,7 +2,6 @@ mod file_fragmenter;
 mod lorawan_adapter;
 mod network_server;
 mod periodic_interferer;
-mod prng;
 mod simulated_radio;
 
 use theatron::scheduler::Scheduler;

--- a/examples/lorawan_file_transfer/prng.rs
+++ b/examples/lorawan_file_transfer/prng.rs
@@ -1,2 +1,0 @@
-// Re-export from the core library to avoid duplication.
-pub use theatron::prng::Xorshift64;


### PR DESCRIPTION
## Summary

`examples/lorawan_file_transfer/prng.rs` was a two-line shim:

```rust
// Re-export from the core library to avoid duplication.
pub use theatron::prng::Xorshift64;
```

It had exactly one caller (`lorawan_adapter.rs`) and exists only to let that caller write `use crate::prng::Xorshift64` instead of `use theatron::prng::Xorshift64`. Inline the import and delete the shim.

Changes:
- `examples/lorawan_file_transfer/lorawan_adapter.rs`: `use crate::prng::Xorshift64` -> `use theatron::prng::Xorshift64`.
- `examples/lorawan_file_transfer/main.rs`: drop `mod prng;`.
- Delete `examples/lorawan_file_transfer/prng.rs`.

## Justification (architecture alignment)

ARCHITECTURE.md "Randomness" specifies that `lorawan-device`'s `Prng` is initialized per-node from the master simulation seed, with `Xorshift64` provided by theatron. The shim added an extra indirection that contradicted "Protocol logic lives outside theatron" by suggesting the example owns its own PRNG namespace — when in fact it transparently re-exports the library's. Importing directly from `theatron::prng` makes the dependency relationship obvious and removes ~3 LOC of indirection.

## Test plan

- [x] `cargo build --examples` — clean locally.
- [x] No public API change; tests in `lorawan_adapter.rs` (`derive_seed_*`) unaffected.
- [ ] CI runs full test suite on the branch.

https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb)_