### PR TITLE
docs: sync ARCHITECTURE.md trait and struct sketches with code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,6 +39,7 @@ struct RxMetadata {
     rssi: f32,
     snr: f32,
     sf: u8,
+    frequency: u32,
     time: SimTime,
 }
 
@@ -48,6 +49,8 @@ struct Transmission {
     bandwidth: u32,
     coding_rate: u8,
     frequency: u32,
+    duration_us: u64,
+    tx_power_dbm: i8,
 }
 ```
 
@@ -253,6 +256,7 @@ Interference sources are first-class simulation participants. They observe the c
 trait InterferenceSource {
     fn observe(&mut self, event: &ChannelEvent, time: SimTime);
     fn poll_inject(&mut self, time: SimTime) -> Option<Transmission>;
+    fn next_poll_time(&self, current_time: SimTime) -> Option<SimTime>;
 }
 ```
 


### PR DESCRIPTION
## Summary

Aligns the illustrative type/trait sketches in `ARCHITECTURE.md` with the canonical definitions in `src/`. Three documentation drifts had accumulated, all in the "Core Abstractions" section:

| Sketch              | Drift                                                        | Code source             |
|---------------------|--------------------------------------------------------------|-------------------------|
| `RxMetadata`        | missing `frequency: u32`                                     | `src/types.rs:34`       |
| `Transmission`      | missing `duration_us: u64` and `tx_power_dbm: i8`            | `src/types.rs:62`       |
| `InterferenceSource` trait | missing `next_poll_time(&self, current_time) -> Option<SimTime>` | `src/traits.rs:93`      |

These fields/methods are load-bearing in the runtime — not optional polish:

- `Transmission.duration_us` is read by `Scheduler::handle_poll_transmit` to schedule the matching `TxComplete` event and to accumulate `total_airtime_us` (`src/scheduler.rs:220`).
- `Transmission.tx_power_dbm` drives RSSI/SNR derivation and the capture-effect resolution in `Channel::begin_transmission` / `Channel::drain_completed` (`src/channel.rs:200`, `src/channel.rs:309`).
- `RxMetadata.frequency` lets adapters discriminate downlinks by channel (used by `SimulatedRadio::inject_downlink` in the lora-rs example).
- `InterferenceSource::next_poll_time` is required by the scheduler to reschedule interferers — without it the scheduler cannot drive event-loop poll-based interferers (`src/scheduler.rs:322`).

## Why functionality is preserved

This PR touches only `ARCHITECTURE.md`. No Rust sources, tests, or configuration are changed — there is no code path to regress. The fix is restoring documentation to match the current implementation, not changing the implementation to match docs.

## Test plan

- [ ] CI: `cargo check --all-features` (unaffected — no code changes)
- [ ] CI: `cargo test --all-features` (unaffected — no code changes)
- [ ] Visual diff review of `ARCHITECTURE.md` sketches vs `src/types.rs` and `src/traits.rs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01173Smn5AbVSYT2cT3QKuNN)_