### PR TITLE
Fix fmt drift and cover channel capture-flag clearing invariant

### DIFF
--- a/examples/lorawan_file_transfer/network_server.rs
+++ b/examples/lorawan_file_transfer/network_server.rs
@@ -56,11 +56,7 @@ mod tests {
     #[test]
     fn on_receive_returns_none() {
         let mut server = NetworkServer::new(NodeId(100));
-        assert!(
-            server
-                .on_receive(make_frame(vec![0x01, 0x02]), 0)
-                .is_none()
-        );
+        assert!(server.on_receive(make_frame(vec![0x01, 0x02]), 0).is_none());
         assert!(server.on_receive(make_frame(vec![0x03]), 1000).is_none());
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -544,6 +544,47 @@ mod tests {
         assert!(strong_entry.2, "strongest should be marked captured");
     }
 
+    /// A transmission can be provisionally `captured` by a weaker overlapping
+    /// signal, then later demoted to `collided` (and un-`captured`) when a
+    /// third equal-power signal arrives. This pins the `else` branch of
+    /// `begin_transmission` that clears a stale `captured` flag — otherwise a
+    /// frame that actually collided would still be reported as captured.
+    #[test]
+    fn captured_flag_cleared_by_later_equal_power_collision() {
+        let mut ch = Channel::new();
+        let strong = make_tx_power(7, 868_100_000, 50_000, 20);
+        let weak = make_tx_power(7, 868_100_000, 50_000, 14);
+        // `strong` captures over `weak` (delta = 6 dB == threshold).
+        ch.begin_transmission(NodeId(1), &strong, 0);
+        ch.begin_transmission(NodeId(2), &weak, 10_000);
+        // A third equal-power signal overlaps `strong`: delta = 0 < threshold,
+        // so `strong` must be demoted from captured to collided.
+        let equal = make_tx_power(7, 868_100_000, 50_000, 20);
+        ch.begin_transmission(NodeId(3), &equal, 20_000);
+        ch.resolve_at(70_000);
+        let completed = ch.drain_completed();
+
+        let strong_entry = completed
+            .iter()
+            .find(|(id, _, _, _)| *id == NodeId(1))
+            .unwrap();
+        assert!(
+            strong_entry.1,
+            "strong must be collided after equal-power overlap"
+        );
+        assert!(
+            !strong_entry.2,
+            "strong's stale captured flag must be cleared by the later collision"
+        );
+        // Nothing survives: no entry is both delivered and captured.
+        assert!(
+            !completed
+                .iter()
+                .any(|(_, collided, captured, _)| !collided && *captured),
+            "no transmission should be delivered-and-captured in this scenario"
+        );
+    }
+
     #[test]
     fn configurable_threshold() {
         let mut ch = Channel::with_config(ChannelConfig {

--- a/tests/interferer_observe_contract.rs
+++ b/tests/interferer_observe_contract.rs
@@ -142,8 +142,7 @@ impl InterferenceSource for InjectingObserver {
 /// model energy detection.
 #[test]
 fn interferer_observes_node_tx_start_and_completion() {
-    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> =
-        Rc::new(RefCell::new(Vec::new()));
+    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> = Rc::new(RefCell::new(Vec::new()));
     let poll_count = Rc::new(RefCell::new(0u32));
 
     let interferer = ObservingInterferer {
@@ -226,8 +225,7 @@ fn interferer_observes_node_tx_start_and_completion() {
 /// hearing its own carrier) depends on.
 #[test]
 fn interferer_observes_its_own_injected_tx() {
-    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> =
-        Rc::new(RefCell::new(Vec::new()));
+    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> = Rc::new(RefCell::new(Vec::new()));
 
     let injector = InjectingObserver {
         inject: RefCell::new(Some(tx(7, 868_100_000, 30_000))),
@@ -334,8 +332,7 @@ fn each_interferer_observes_other_interferers_tx() {
 /// from collisions.
 #[test]
 fn interferer_observes_collided_flag_on_completion() {
-    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> =
-        Rc::new(RefCell::new(Vec::new()));
+    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> = Rc::new(RefCell::new(Vec::new()));
     let poll_count = Rc::new(RefCell::new(0u32));
 
     let interferer = ObservingInterferer {
@@ -381,8 +378,7 @@ fn interferer_observes_collided_flag_on_completion() {
 /// transmissions it intended to suppress.
 #[test]
 fn next_poll_time_none_permanently_stops_polling() {
-    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> =
-        Rc::new(RefCell::new(Vec::new()));
+    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> = Rc::new(RefCell::new(Vec::new()));
     let poll_count = Rc::new(RefCell::new(0u32));
 
     let interferer = ObservingInterferer {
@@ -409,8 +405,7 @@ fn next_poll_time_none_permanently_stops_polling() {
 /// (rolling averages, duty-cycle accounting, exponential backoff).
 #[test]
 fn observed_event_times_are_non_decreasing() {
-    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> =
-        Rc::new(RefCell::new(Vec::new()));
+    let observations: Rc<RefCell<Vec<(ChannelEvent, SimTime)>>> = Rc::new(RefCell::new(Vec::new()));
     let poll_count = Rc::new(RefCell::new(0u32));
 
     let interferer = ObservingInterferer {


### PR DESCRIPTION
Maintenance pass across the three workstreams. The repository is already
in very good shape from prior passes, so changes are deliberately small
and focused.

## Architecture
No clear, low-risk non-compliance with `ARCHITECTURE.md` was found. The
source already matches the documented design (event-driven scheduler,
format-agnostic channel, seeded PRNG, interferers as first-class
participants). The minor struct drift (`Transmission` / `RxMetadata`
carry extra physical-layer fields vs. the doc sketches) is consistent
with `ARCHITECTURE.md` being an explicitly-labelled proposal, so it was
left alone rather than churned. No worthwhile LOC/complexity reduction
was identified that wouldn't risk behaviour.

## Testing
Most undertested core behaviour: the capture-effect bookkeeping in
`Channel::begin_transmission`. The capture/collision branches were well
covered *except* the `else` branch that clears a stale `captured` flag
when a third equal-power transmission overlaps an already-captured one.

- Added `captured_flag_cleared_by_later_equal_power_collision` to
  `src/channel.rs`, pinning the invariant that a provisionally captured
  transmission is demoted to `collided` (and un-`captured`) by a later
  equal-power overlap. Without this guarantee a frame that actually
  collided could be reported as captured.

## Clarity
- Re-ran `cargo fmt --all`: the committed tree had drifted from current
  rustfmt output in `examples/lorawan_file_transfer/network_server.rs`
  and `tests/interferer_observe_contract.rs`, which would fail the
  pre-commit `format` hook and the documented
  `cargo fmt --all -- --check` workflow for any local developer.

Local verification: `cargo fmt --all -- --check`, `cargo clippy
--all-features --all-targets -- -D warnings`, and `cargo test
--all-features` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C18s7J23s2b9R64jzfKQAb)_